### PR TITLE
Make the makefile care about whether the target is already up to date.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,15 @@ ifndef SITE
 SITE=""
 endif
 
-ifeq ($(strip $(OS)),"") 
-$(error "OS must be set to one of $(all_os)")
-endif
-ifeq ($(strip $(SITE)),"")
-$(error "SITE must be set to one of $(all_site)")
-endif
-
-
 all: $(document_pdf)
 
 $(document_pdf): ch_*.tex HPC.tex
+ifeq ($(strip $(OS)),"") 
+	echo "OS must be set to one of $(all_os)"
+endif
+ifeq ($(strip $(SITE)),"")
+	echo "SITE must be set to one of $(all_site)"
+endif
 	$(latex_command)
 	makeglossaries $(jobname)
 	$(latex_command)


### PR DESCRIPTION
This patch will make it such that files will only be built if they weren't already done.

The previous file also had a bunch of rules which were pointless. Just use environment variables for variables instead of n*m rules per variable.
