### PR TITLE
UGent now uses login.hpc.ugent.be for login nodes.

### DIFF
--- a/intro-HPC/macros.tex
+++ b/intro-HPC/macros.tex
@@ -9,7 +9,7 @@
 \macro{\sitename}{gent}
 \macro{\hpc}{HPC-UGent}
 \macro{\jobid}{123456.master15.delcatty.gent.vsc}
-\macro{\loginnode}{gengar.ugent.be}
+\macro{\loginnode}{login.hpc.ugent.be}
 \macro{\computenode}{node2005.delcatty.os}
 \macro{\userid}{vsc40000}
 \macro{\homedir}{/user/home/gent/vsc400/vsc40000}


### PR DESCRIPTION
Now we're consistent and users will no longer be confused why they are logging
into gengar when we just turned gengar off.

`vsc_consistency++`
