### PR TITLE
Cleanup of .tex files (training @ UAntwerpen, October 13, 2014)

### DIFF
--- a/intro-HPC/antwerpen/ch_hpc_policies.tex
+++ b/intro-HPC/antwerpen/ch_hpc_policies.tex
@@ -1,4 +1,5 @@
 \chapter{HPC Policies}
+\label{ch:hpc-policies}
 
 The cluster has been setup to support the ongoing research in all the domains
 at the University of Antwerp.  As such, it should be considered as valuable
@@ -14,6 +15,7 @@ implemented:
 \item  Fairshare mechanism
 \item  Crediting system
 \end{enumerate}
+
 
 \section{Single user node policy}
 
@@ -35,6 +37,7 @@ The scheduler will (try to) fill up a node with several jobs from the same
 user. If you don't have enough work for a single node, you need a good PC and
 not a supercomputer.
 
+
 \section{Priority based scheduling?}
 
 The scheduler associates a priority number to each job:
@@ -53,6 +56,7 @@ Currently, the priority calculation is based on:
 
 The Priority system can of course be adapted in the future, but this will be will be communicated.
 
+
 \section{Fairshare mechanism}
 
 A ``\emph{Fairshare}'' system has been setup to allow all users to get their
@@ -67,6 +71,7 @@ allocation of computing time.
 
 \includegraphics*[width=5.77in, height=2.37in, keepaspectratio=false]{img0900}
 
+
 \section{Crediting system}
 
-There is no crediting system in use yet at the \hpc.
+Every group gets every Monday an overview of the credits used by its researchers during the last week on the \hpc.

--- a/intro-HPC/antwerpen/ch_monitoring_utilization.tex
+++ b/intro-HPC/antwerpen/ch_monitoring_utilization.tex
@@ -1,4 +1,5 @@
-\chapter{Monitoring UA-HPC Utilization with Ganglia}
+\chapter{Monitoring Cluster Utilization}
+\label{ch:monitoring-cluster-utilization}
 
 \section{Introduction}
 
@@ -10,8 +11,8 @@ depending on who is saying it and who is hearing it.
 For example:
 
 \begin{enumerate}
-\item  The \strong{end-users} (persons running applications on the cluster) think: "When will my job start and when will it be finished? Did I specify the right computer resources?  How is it performing compared to last time and can I speed it up?"
-\item  The \strong{systems engineers} of the UA-HPC think: "How are our machines performing? Are all the services functioning correctly? What trends do we see and how can we better utilize our overall computer resources?"
+\item  The \strong{end-users} (persons running applications on the cluster) think: ``When will my job start and when will it be finished? Did I specify the right computer resources?  How is it performing compared to last time and can I speed it up?''
+\item  The \strong{systems engineers} of the UA-HPC think: ``How are our machines performing? Are all the services functioning correctly? What trends do we see and how can we better utilize our overall computer resources?''
 \end{enumerate}
 
 The UA-HPC provides an UA-HPC utilization information system, which is based on Ganglia.
@@ -62,7 +63,7 @@ process at a time) and the 1-min load average. If the system is getting fully
 utilized the 1-min load average would approach the total number of CPUs.
 
 \begin{enumerate}
-\item  The red horizontal line counts the number of available cores in the cluster. Anno 2013, we have 2496 (=2,4k) individual cores in the cluster.
+\item  The red horizontal line counts the number of available cores in the cluster. Anno 2013, we have 2496 (=2.4 k) individual cores in the cluster.
 \item  The blue vibrating line shows the actual number of active cores. In the perfect world with a perfectly utilized cluster and with the perfect software this could approach the red line. The reality is however different with a score of approximately 60\% usage. For example, processes (software), which are consuming a lot of memory in a node, could cause a number of cores in the node to be inactive.  Most of the time, inactivity of cores inside a node is being caused by the inappropriate requests for certain computer resources by a user.
 \end{enumerate}
 
@@ -76,7 +77,7 @@ While the load chart gives a good overall impression of usage, the utilization t
 
 \begin{enumerate}
 \item  The percentage of CPU consumed by the user is shown in blue.
-\item  The percentage of CPU consumed by system processes is shown in red, and should optimally be non-visible.  A huge amount of system CPU is typically caused by processes which are communicating a lot over the Gigabit network. Users could solve this easily by requesting to use the Infiniband network.
+\item  The percentage of CPU consumed by system processes is shown in red, and should optimally be non-visible.  A huge amount of system CPU is typically caused by processes which are communicating a lot over the gigabit network. Users could solve this easily by requesting to use the Infiniband network.
 \end{enumerate}
 
 \subsubsection{Cluster Memory usage.}
@@ -128,7 +129,7 @@ Job ID               Username Queue    Jobname          SessID NDS   TSK Memory 
 \end{prompt}
 
 If you do not see any node, you might have to start a job first. Any of the
-previous examples will do, e.g., take the exercise of Chapter 4 that generates
+previous examples will do, e.g., take the exercise of \autoref{ch:running-batch-jobs} that generates
 some files.
 
 
@@ -188,7 +189,7 @@ request more memory than is available, which results in significant slower
 performances.
 
 \begin{enumerate}
-\item  The red line shows the available memory in the node, i.e. 24GB in this example.
+\item  The red line shows the available memory in the node, i.e., 24GB in this example.
 \item  The percentage of the used memory is shown in blue (your application),
   green and red.  When you use more memory than is available in your node, the
   computer will start swapping memory and seriously slow down.

--- a/intro-HPC/antwerpen/contact-information.tex
+++ b/intro-HPC/antwerpen/contact-information.tex
@@ -1,13 +1,13 @@
 \begin{enumerate}
 \item  By e-mail:  \hpcinfo
-\item  By Phone : 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert)
-\item  In real  : Campus Middelheim, Building G, Room G.309 and G.310
+\item  By phone: 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert)
+\item  In real: Campus Middelheim, Building G, Room G.309 and G.310
 \end{enumerate}
 
 Mailing-lists:
 
 \begin{enumerate}
 \item  Announcements: \hpcannounceml (for official announcements and communications)
-\item  Users : \hpcusersml (for discussions between users)
+\item  Users: \hpcusersml (for discussions between users)
 \end{enumerate}
 

--- a/intro-HPC/antwerpen/macros.tex
+++ b/intro-HPC/antwerpen/macros.tex
@@ -8,14 +8,16 @@
 \macro{\loginnode}{login.hpc.uantwerpen.be}
 \macro{\loginhost}{ln02.hopper.uantwerpen.vsc}
 \macro{\operatingsystem}{Scientifc Linux release 6.4 (Carbon)}
+\macro{\operatingsystemSL}{Scientifc Linux}
+\macro{\operatingsystemRHEL}{RedHat Enterprise Linux}
 \macro{\tutorialdir}{/apps/antwerpen/tutorials}
 \macro{\examplesdir}{/apps/antwerpen/tutorials/Intro-HPC/examples}
 % Demo user, jobs, nodes, etc
 \macro{\userid}{vsc20167}
 \macro{\homedir}{/user/antwerpen/201/vsc20167}
 \macro{\jobid}{433253.master1.hopper.antwerpen.vsc}
-\macro{\computenode}{r5e3cn13.hopper.antwerpen.vsc}
-\macro{\computenode}{r4e2cn03}
+\macro{\computenode}{r5c3cn13.hopper.antwerpen.vsc}
+\macro{\computenodeshort}{r5c3cn13}
 % Support 
 \macro{\hpcinfo}{hpc@uantwerpen.be}
 \macro{\hpcusersml}{calcua-users@sympa.ua.ac.be}

--- a/intro-HPC/antwerpen/queue-table.tex
+++ b/intro-HPC/antwerpen/queue-table.tex
@@ -1,9 +1,20 @@
-\begin{tabular}{|p{0.6in}|p{1.4in}|p{1.2in}|p{0.9in}|p{0.9in}|} \hline
-\strong{Queue\newline category} & \multicolumn{2}{|p{1.5in}|}{\strong{Walltime}} & \multicolumn{2}{|p{1.4in}|}{\strong{Max \# Jobs}} \\ \hline
-\strong{} & \strong{Minimum / from\newline (value not included)} & \strong{Maximum / to \newline (value included)} & \strong{Queuable} & \strong{Runnable} \\ \hline
-qshort  & 0      & 1 hour  & 1000 & 500 \\ \hline
-qreg    & 1 hour & 1 day   & 1000 & 100 \\ \hline
-qlong   & 1 day  & 3 days  & 500  & 100 \\ \hline
-qxlong  & 3 days & 7 days  & 50   & 25  \\ \hline
-qxxlong & 7 days & 21 days & 8    & 2   \\ \hline
+%\begin{tabular}{|p{0.6in}|p{1.4in}|p{1.2in}|p{0.9in}|p{0.9in}|} \hline
+%\strong{Queue\newline category} & \multicolumn{2}{|p{1.5in}|}{\strong{Walltime}} & \multicolumn{2}{|p{1.4in}|}{\strong{Max \# Jobs}} \\ \hline
+%\strong{} & \strong{Minimum / from\newline (value not included)} & \strong{Maximum / to \newline (value included)} & \strong{Queuable} & \strong{Runnable} \\ \hline
+%qshort  & 0      & 1 hour  & 1000 & 500 \\ \hline
+%qreg    & 1 hour & 1 day   & 1000 & 100 \\ \hline
+%qlong   & 1 day  & 3 days  & 500  & 100 \\ \hline
+%qxlong  & 3 days & 7 days  & 50   & 25  \\ \hline
+%qxxlong & 7 days & 21 days & 8    & 2   \\ \hline
+%\end{tabular}
+
+
+\begin{tabular}{|p{1.4in}|p{1.2in}|p{0.9in}|p{0.9in}|} \hline
+\multicolumn{2}{|p{1.5in}|}{\strong{Walltime}} & \multicolumn{2}{|p{1.4in}|}{\strong{Max \# Jobs}} \\ \hline
+\strong{Minimum / from\newline (value not included)} & \strong{Maximum / to \newline (value included)} & \strong{Queuable} & \strong{Runnable} \\ \hline
+0      & 1 hour  & 1000 & 500 \\ \hline
+1 hour & 1 day   & 1000 & 100 \\ \hline
+1 day  & 3 days  & 500  & 100 \\ \hline
+3 days & 7 days  & 50   & 25  \\ \hline
+7 days & 21 days & 8    & 2   \\ \hline
 \end{tabular}

--- a/intro-HPC/brussel/ch_hpc_policies.tex
+++ b/intro-HPC/brussel/ch_hpc_policies.tex
@@ -1,4 +1,5 @@
 \chapter{HPC Policies}
+\label{ch:hpc-policies}
 
 The cluster has been setup to support the ongoing research in all the domains
 at the University of Antwerp.  As such, it should be considered as valuable

--- a/intro-HPC/brussel/ch_monitoring_utilization.tex
+++ b/intro-HPC/brussel/ch_monitoring_utilization.tex
@@ -1,4 +1,5 @@
-\chapter{Monitoring UA-HPC Utilization with Ganglia}
+\chapter{Monitoring Cluster Utilization}
+\label{ch:monitoring-cluster-utilization}
 
 \section{Introduction}
 
@@ -10,8 +11,8 @@ depending on who is saying it and who is hearing it.
 For example:
 
 \begin{enumerate}
-\item  The \strong{end-users} (persons running applications on the cluster) think: "When will my job start and when will it be finished? Did I specify the right computer resources?  How is it performing compared to last time and can I speed it up?"
-\item  The \strong{systems engineers} of the UA-HPC think: "How are our machines performing? Are all the services functioning correctly? What trends do we see and how can we better utilize our overall computer resources?"
+\item  The \strong{end-users} (persons running applications on the cluster) think: ``When will my job start and when will it be finished? Did I specify the right computer resources?  How is it performing compared to last time and can I speed it up?''
+\item  The \strong{systems engineers} of the UA-HPC think: ``How are our machines performing? Are all the services functioning correctly? What trends do we see and how can we better utilize our overall computer resources?''
 \end{enumerate}
 
 The UA-HPC provides an UA-HPC utilization information system, which is based on Ganglia.
@@ -62,7 +63,7 @@ process at a time) and the 1-min load average. If the system is getting fully
 utilized the 1-min load average would approach the total number of CPUs.
 
 \begin{enumerate}
-\item  The red horizontal line counts the number of available cores in the cluster. Anno 2013, we have 2496 (=2,4k) individual cores in the cluster.
+\item  The red horizontal line counts the number of available cores in the cluster. Anno 2013, we have 2496 (=2.4 k) individual cores in the cluster.
 \item  The blue vibrating line shows the actual number of active cores. In the perfect world with a perfectly utilized cluster and with the perfect software this could approach the red line. The reality is however different with a score of approximately 60\% usage. For example, processes (software), which are consuming a lot of memory in a node, could cause a number of cores in the node to be inactive.  Most of the time, inactivity of cores inside a node is being caused by the inappropriate requests for certain computer resources by a user.
 \end{enumerate}
 
@@ -76,7 +77,7 @@ While the load chart gives a good overall impression of usage, the utilization t
 
 \begin{enumerate}
 \item  The percentage of CPU consumed by the user is shown in blue.
-\item  The percentage of CPU consumed by system processes is shown in red, and should optimally be non-visible.  A huge amount of system CPU is typically caused by processes which are communicating a lot over the Gigabit network. Users could solve this easily by requesting to use the Infiniband network.
+\item  The percentage of CPU consumed by system processes is shown in red, and should optimally be non-visible.  A huge amount of system CPU is typically caused by processes which are communicating a lot over the gigabit network. Users could solve this easily by requesting to use the Infiniband network.
 \end{enumerate}
 
 \subsubsection{Cluster Memory usage.}
@@ -128,7 +129,7 @@ Job ID               Username Queue    Jobname          SessID NDS   TSK Memory 
 \end{prompt}
 
 If you do not see any node, you might have to start a job first. Any of the
-previous examples will do, e.g., take the exercise of Chapter 4 that generates
+previous examples will do, e.g., take the exercise of chapter~\ref{ch:running-batch-jobs} that generates
 some files.
 
 
@@ -188,7 +189,7 @@ request more memory than is available, which results in significant slower
 performances.
 
 \begin{enumerate}
-\item  The red line shows the available memory in the node, i.e. 24GB in this example.
+\item  The red line shows the available memory in the node, i.e., 24GB in this example.
 \item  The percentage of the used memory is shown in blue (your application),
   green and red.  When you use more memory than is available in your node, the
   computer will start swapping memory and seriously slow down.

--- a/intro-HPC/brussel/contact-information.tex
+++ b/intro-HPC/brussel/contact-information.tex
@@ -1,13 +1,13 @@
 \begin{enumerate}
 \item  By e-mail:  \hpcinfo
-\item  By Phone : 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert)
-\item  In real  : Campus Middelheim, Building G, Room G.309 and G.310
+\item  By phone: 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert)
+\item  In real: Campus Middelheim, Building G, Room G.309 and G.310
 \end{enumerate}
 
 Mailing-lists:
 
 \begin{enumerate}
 \item  Announcements: \hpcannounceml (for official announcements and communications)
-\item  Users : \hpcusersml (for discussions between users)
+\item  Users: \hpcusersml (for discussions between users)
 \end{enumerate}
 

--- a/intro-HPC/ch_account.tex
+++ b/intro-HPC/ch_account.tex
@@ -39,7 +39,7 @@ Terminal.
   do not even need to install; just download the executable and run it!
   Alternatively, an installation package is also available.
 
-  Download PuTTY and install it in the C:/Program Files (x86)/PuTTY directory.
+  Download PuTTY and install it in the C:\textbackslash Program Files (x86)\textbackslash PuTTY directory.
 
   Google ``\emph{PuTTY download}'' or go directly to the official download
   address: \url{http://www.chiark.greenend.org.uk/\~sgtatham/putty/}
@@ -48,8 +48,8 @@ Terminal.
 
   \begin{enumerate}
     \item  \strong{PuTTY}: the Telnet and SSH client itself
-    \item  \strong{PSCP}: an SCP client, i.e. command-line secure file copy
-    \item  \strong{PSFTP}: an SFTP client, i.e. general file transfer sessions much like FTP
+    \item  \strong{PSCP}: an SCP client, i.e., command-line secure file copy
+    \item  \strong{PSFTP}: an SFTP client, i.e., general file transfer sessions much like FTP
     \item  \strong{Plink}: a command-line interface to the PuTTY back ends
     \item  \strong{Pageant}: an SSH authentication agent for PuTTY, PSCP and Plink
     \item  \strong{PuTTYgen}: an RSA and DSA key generation utility
@@ -71,19 +71,19 @@ Terminal.
   Start \strong{\emph{PuTTYgen.exe}} it and follow these steps:
 
   \begin{enumerate}
-    \item  In $<$\emph{Parameters}$>$ (at the bottom of the window), choose
-      'SSH-2 RSA' and set the number of bits in the key to 2048.
+    \item  In \keys{Parameters} (at the bottom of the window), choose
+      ``SSH-2 RSA'' and set the number of bits in the key to 2048.
 
     \includegraphics*[width=3.49in, height=3.38in, keepaspectratio=false]{ch2-puttygen-bits}
 
-    \item  Click on $<$\emph{Generate}$>$. To generate the key, you must move
+    \item  Click on \keys{Generate}. To generate the key, you must move
       the mouse cursor over the PuTTYgen window (this generates some random
       data that PuTTYgen uses to generate the key pair). Once the key pair is
-      generated, your public key is shown in the field $<$\emph{Public key for pasting into OpenSSH authorized\_keys file}$>$.
-    \item  Next, it is advised to fill in the $<$\emph{Key comment}$>$ field
+      generated, your public key is shown in the field \keys{Public key for pasting into OpenSSH authorized\_keys file}.
+    \item  Next, it is advised to fill in the \keys{Key comment} field
       to make it easier identifiable afterwards.
-    \item  Next, you should specify a passphrase in the $<$\emph{Key passphrase}$>$
-      field and retype it in the $<$\emph{Confirm passphrase}$>$ field.
+    \item  Next, you should specify a passphrase in the \keys{Key passphrase}
+      field and retype it in the \keys{Confirm passphrase} field.
       Remember, the passphrase protects the private key against unauthorized
       use, so it is best to choose one that is not too easy to guess but that
       you can still remember.
@@ -94,9 +94,9 @@ Terminal.
       personal computer (We recommend to create and put them in the folder
       ``C:\textbackslash Users\textbackslash \%USERNAME\%\textbackslash
       AppData\textbackslash Local\textbackslash PuTTY\textbackslash .ssh'')
-      with the buttons $<$\emph{Save public key}$>$ and $<$\emph{Save private key}$>$.
-      We recommend using the name "\strong{id\_rsa.pub}" for the public key,
-      and "\strong{id\_rsa.ppk}" for the private key.
+      with the buttons \keys{Save public key} and \keys{Save private key}.
+      We recommend using the name ``\strong{id\_rsa.pub}'' for the public key,
+      and ``\strong{id\_rsa.ppk}'' for the private key.
   \end{enumerate}
 
   If you use another program to generate a key pair, please remember that they
@@ -183,9 +183,9 @@ ls: .ssh: No such file or directory
 \end{prompt}
 
   You can recognize a public/private key pair when a pair of files has the same
-  name except for the extension ".pub" added to one of them. In this particular
-  case, the private key is "id\_rsa" and public key is "id\_rsa.pub". You may
-  have multiple keys (not necessarily in the directory "\tilde/.ssh") if you or
+  name except for the extension ``.pub'' added to one of them. In this particular
+  case, the private key is ``id\_rsa'' and public key is ``id\_rsa.pub''. You may
+  have multiple keys (not necessarily in the directory ``\tilde/.ssh'') if you or
   your operating system requires this.
 
   You will need to generate a new key pair, when:
@@ -195,9 +195,9 @@ ls: .ssh: No such file or directory
     \item  or your private key was compromised.
   \end{enumerate}
 
-  For extra security, the private key itself is encrypted using a 'passphrase',
+  For extra security, the private key itself is encrypted using a ``passphrase'',
   to prevent anyone from using your private key even when they manage to copy
-  it. You have to 'unlock' the private key by typing the passphrase.
+  it. You have to ``unlock'' the private key by typing the passphrase.
 
 \begin{prompt}
 %\shellcmd{ssh-keygen}%
@@ -229,22 +229,22 @@ Other users of the \association, need to follow the instructions in \autoref{sec
 \label{sec:users-of-university}
 
 Open the following webpage from within the \university campus network (or using a VPN
-connection) \url{https://account.vscentrum.be/req} and choose `\sitename' as your VSC
+connection) \url{https://account.vscentrum.be/req} and choose ``\sitename'' as your VSC
 site.
 
 Browse to \url{https://account.vscentrum.be/req}
 
-Choose `\sitename' as your VSC site.
+Choose ``\sitename'' as your VSC site.
 
 Click $<$Submit$>$
 
 \includegraphics*[width=5.77in, height=3.51in, keepaspectratio=false]{ch2-browser-select-site}
 
-You will now be taken to a website of BELNET, where you must authenticate yourself.
+You will now be taken to a website of BELNET, where you have to select your ``Home Organization''.
 
 \includegraphics*[width=5.73in, height=4.00in, keepaspectratio=false]{ch2-browser-authenticate}
 
-Select `\university' in the dropdown box.
+Select ``\university'' in the dropdown box.
 
 Click $<$Select$>$
 
@@ -256,31 +256,33 @@ You will now be taken to the authentification page of your institute.
 
 After you log in using your \university login and password (the one you also
 use for Webmail, \ldots ), you will be asked to upload the file that contains
-your public key, i.e. the file `id\_rsa.pub' which you should already have
+your public key, i.e., the file ``id\_rsa.pub'' which you should already have
 generated.
 
 \ifwindows
   This file should have been stored in the directory
-  `\emph{/Users/$<$Username$>$/PuTTY/.ssh/}'.
+  ``\emph{/Users/$<$Username$>$/PuTTY/.ssh/}''.
 \fi
 \ifmacORlinux
-  This file has been stored in the directory `\emph{\tilde/.ssh/}'.
+  This file has been stored in the directory ``\emph{\tilde/.ssh/}''.
 \fi
 
 \ifmac
-  \strong{\underbar{Tip:}} As ".ssh" is an invisible directory, the Finder will
+\begin{tip}
+  As ``.ssh'' is an invisible directory, the Finder will
   not show it by default. The easiest way to access the folder, is by pressing
   Apple-Shift--G, which will allow you to enter the name of a directory, which
-  you would like to open in Finder. Here, type "\tilde/.ssh" and press enter.
+  you would like to open in Finder. Here, type ``\tilde/.ssh'' and press enter.
+\end{tip}
 \fi
 
 You will get an e-mail to confirm your account request. After the VSC staff has
-approved the account, your account will be created and you will get
+approved the account, your account will be created and you will get a
 confirmation e-mail.
 
 \ifantwerpen % IF ANTWERPEN
 \strong{The site is only accessible from within the \university
-domain}, so the page won't load from (e.g.) home. However, you can also get
+domain}, so the page won't load from, e.g., home. However, you can also get
 external access to the \university domain using VPN. We refer to the \university ICT infocenter
 for more information.
 
@@ -293,18 +295,18 @@ yet an automated form to request for your personal VSC account.
 
 Please e-mail the \hpc staff to get an account (see Contacts information).
 You will have to provide a public \emph{ssh} key generated as described
-above. Please attach your public key (i.e., the file named `id\_rsa.pub'),
+above. Please attach your public key (i.e., the file named ``id\_rsa.pub''),
 which you will normally find in your .ssh subdirectory within your HOME
-Directory. (i.e. /Users/$<$username$>$/.ssh/id\_rsa.pub).
+Directory. (i.e., /Users/$<$username$>$/.ssh/id\_rsa.pub).
 
 
 \ifmac % IF MAC
-
-  \strong{\underbar{Tip:}} As ".ssh" is an invisible directory, the Finder will
+\begin{tip}
+  As ``.ssh'' is an invisible directory, the Finder will
   not show it by default. The easiest way to access the folder, is by pressing
   Apple-Shift-G, which will allow you to enter the name of a directory, which
-  you would like to open in Finder. Here, type "\tilde/.ssh" and press enter.
-
+  you would like to open in Finder. Here, type ``\tilde/.ssh'' and press enter.
+\end{tip}
 \fi % END IF MAC
 \fi % END IF ANTWERPEN
 
@@ -341,7 +343,7 @@ Now, you can start using the \hpc.
 
   \begin{enumerate}
     \item  Start the PuTTY executable $<$\strong{\emph{putty.exe}}$>$ in your
-      directory `\strong{\emph{C:/Program Files (x86)/PuTTY}}' and the
+      directory ``\strong{\emph{C:\textbackslash Program Files (x86)\textbackslash PuTTY}}'' and the
       configuration screen will pop up. As you will often use the PuTTY tool,
       we recommend adding a shortcut on your desktop.
     \item  Within the category $<$\strong{\emph{Session}}$>$, in the field
@@ -351,32 +353,32 @@ Now, you can start using the \hpc.
 
     \includegraphics*[width=3.59in, height=3.45in, keepaspectratio=false]{ch2-putty-configuration}
 
-    \item  In the category $<$\emph{Connection}$>$ $<$\emph{Data}$>$, in
-      the field $<$\emph{Auto-login username}$>$, put in
+    \item  In the category \menu[,]{Connection,Data}, in
+      the field \keys{Auto-login username}, put in
       $<$\emph{vsc-account}$>$, which is your VSC username that you have
       received by mail after your request was approved.
 
   \includegraphics*[width=3.11in, height=2.99in, keepaspectratio=false]{ch2-putty-configuration2}
 
-    \item  In the category $<$\emph{Connection$>$$<$SSH$>$$<$Auth$>$}, in the
-      field $<$\emph{Private key file for authentication}$>$ click on
-      $<$\emph{Browse}$>$ and select the private key (i.e., `id\_rsa.ppk')
+    \item  In the category \menu[,]{Connection,SSH,Auth}, in the
+      field \keys{Private key file for authentication} click on
+      \keys{Browse} and select the private key (i.e., ``id\_rsa.ppk'')
       that you generated and saved above.
 
   \includegraphics*[width=3.25in, height=3.13in, keepaspectratio=false]{ch2-putty-key-setup}
 
-    \item  In the category $<$\emph{Connection$>$$<$SSH $>$$<$X11$>$}, click
-      the $<$\emph{Enable X11 Forwarding}$>$ checkbox.
+    \item  In the category \menu[,]{Connection,SSH,X11}, click
+      the \keys{Enable X11 Forwarding} checkbox.
 
   \includegraphics*[width=3.54in, height=3.41in, keepaspectratio=false]{ch2-putty-x-forwarding}
 
     \item  Now go back to $<$Session$>$, and fill in ``\emph{\hpcname}'' in the
-      $<$\emph{Saved Sessions}$>$ field and press $<$\emph{Save}$>$ to
+      \keys{Saved Sessions} field and press \keys{Save} to
       store the session information.
 
   \includegraphics*[width=3.30in, height=3.17in, keepaspectratio=false]{ch2-putty-saved-session}
 
-    \item  Now pressing $<$\emph{Open}$>$, will open a terminal window and
+    \item  Now pressing \keys{Open}, will open a terminal window and
       asks for you passphrase.
 
   \includegraphics*[width=3.94in, height=2.47in, keepaspectratio=false]{ch2-putty-enter-password}
@@ -394,19 +396,20 @@ Now, you can start using the \hpc.
 
   \begin{prompt}
   %\shellcmd{pwd}%
-  /homedir
+  %\homedir%
   %\shellcmd{hostname --f}%
-  \loginhost
+  %\loginhost%
   \end{prompt}
 
     \item  For future PuTTY sessions, just select your saved session (i.e.
-      ``\emph{\hpcname}'') from the list, $<$\emph{Load}$>$ it and press
-      $<$\emph{Open}$>$.
+      ``\emph{\hpcname}'') from the list, \keys{Load} it and press
+      \keys{Open}.
   \end{enumerate}
 
 %ENDIF windos
 \fi
 
+\ifmacORlinux
 \subsection{Connect}
 \label{sec:connect}
 
@@ -423,7 +426,7 @@ Here,
 
 \begin{enumerate}
   \item  \emph{$<$vsc-account$>$} is your VSC username that you have received
-    by mail after your request was approved (e.g. \userid),
+    by mail after your request was approved (e.g., \userid),
   \item  \emph{``\loginnode''} is the name of the login
     node of the \hpc cluster you want to connect to.
 \end{enumerate}
@@ -433,15 +436,15 @@ verify the authenticity of the login node, e.g.,
 
 \begin{prompt}
 %\shellcmd{ssh \userid{}@\loginnode{}}%
-The authenticity of host `%\loginnode% (<IP-adress>)' can't be established.
+The authenticity of host ``%\loginnode% (<IP-adress>)'' can't be established.
 RSA key fingerprint is b7:66:42:23:5c:d9:43:e8:b8:48:6f:2c:70:de:02:eb.
 Are you sure you want to continue connecting (yes/no)? %\strong{\emph{yes}}%
 \end{prompt}
 
-Here, user \userid wants to make a connection to the `\hpcname' cluster at
-\university via the login node '\loginnode'.
+Here, user \userid wants to make a connection to the ``\hpcname'' cluster at
+\university via the login node ``\loginnode''.
 
-\strong{Congratulations, you're on the \hpc Super-Computer now !!!}
+\strong{Congratulations, you're on the \hpc Super-Computer now!}
 Okay, I am on the supercomputer, but where am I?
 
 So, print the current working directory:
@@ -449,6 +452,8 @@ So, print the current working directory:
 %\shellcmd{pwd}%
 %\homedir%
 \end{prompt}
+\fi
+
 
 Your new private home-directory is ``\homedir''.
 Here you can create your own sub-directory structure, copy and prepare your
@@ -486,23 +491,18 @@ As we are interested in the use of the \strong{\emph{HPC}}, move further to
 %\shellcmd{cd intro-HPC}%
 %\shellcmd{tree -L 2}%
 .
-%\textbar%-- HPC_Tutorial_Linux.pdf
-%\textbar%-- HPC_Tutorial_Mac.pdf
-%\textbar%-- HPC_Tutorial_Win.pdf
-%\textbar%-- HPC_slides.pdf
-%\textbar%-- docs
 `-- examples
-    %\textbar%-- ch04_Batch
-    %\textbar%-- ch05_Interactive
-    %\textbar%-- ch06_Files
-    %\textbar%-- ch07_Parallel
-    %\textbar%-- ch08_MultiJob
-    %\textbar%-- ch10_Compile
-    %\textbar%-- ch11_TuneJobs
-    %\textbar%-- ch13_Examples
+    %\textbar%-- Compiling-and-testing-your-software-on-the-HPC
+    %\textbar%-- Fine-tuning-Job-Specifications 
+    %\textbar%-- Multi-core-jobs-Parallel-Computing 
+    %\textbar%-- Multi-job-submission
+    %\textbar%-- Program-examples
+    %\textbar%-- Running-batch-jobs
+    %\textbar%-- Running-jobs-with-input
+    %\textbar%-- Running-jobs-with-input-output-data
     %\textbar%-- example.pbs
     `-- example.sh
-10 directories, 5 files
+9 directories, 5 files
 \end{prompt}
 
 This directory contains:
@@ -520,19 +520,23 @@ This directory contains:
 %\shellcmd{cd examples}%
 \end{prompt}
 
-\strong{Tip: }Typing ``\strong{\emph{cd ex$<$TAB$>$}}'' will generate the
+\begin{tip}
+Typing ``\strong{\emph{cd ex$<$TAB$>$}}'' will generate the
 ``\strong{\emph{cd examples}}'' command. \strong{Command-line completion
 }(also tab completion) is a common feature of the bash command line
 interpreter, in which the program automatically fills in partially typed
 commands.
+\end{tip}
 
-\strong{\underbar{Tip:}} For more exhaustive tutorials about Linux usage,
+\begin{tip}
+For more exhaustive tutorials about Linux usage,
 please refer to the following sites:
 
 \begin{enumerate}
   \item \url{http://www.linux.org/lessons/}
   \item \url{http://linux.about.com/od/nwb\_guide/a/gdenwb06.htm}
 \end{enumerate}
+\end{tip}
 
 The first action is to copy the contents of the \hpc examples directory 
 to your home directory, so that you have your own personal copy and that 
@@ -543,7 +547,7 @@ will also copy the contents of the sub-directories ``\emph{recursively}''.
 %\shellcmd{cp --r \examplesdir \tilde/}%
 \end{prompt}
 
-Go to your home directory, check your own private examples directory, \dots  and start working.
+Go to your home directory, check your own private examples directory, \dots\  and start working.
 
 %\shellcmd{cd}%
 %\shellcmd{ls -l}%

--- a/intro-HPC/ch_checkpointing.tex
+++ b/intro-HPC/ch_checkpointing.tex
@@ -1,3 +1,4 @@
 \chapter{Checkpointing}
+\label{ch:checkpointing}
 
 \textit{This chapter is still under construction.}

--- a/intro-HPC/ch_compiling_your_software.tex
+++ b/intro-HPC/ch_compiling_your_software.tex
@@ -1,4 +1,5 @@
 \chapter{Compiling and testing your software on the HPC}
+\label{ch:compiling-and-testing-your-software-on-the-hpc}
 
 All nodes in the \hpc cluster are running the ``\operatingsystem'' Operating
 system, which is a specific version of RedHat-Linux. This means that all the
@@ -25,7 +26,7 @@ is often preferred.
 
 To \strong{port} a software-program is to translate it from the operating
 system in which it was developed (e.g., Windows 7) to another operating system
-(e.g., Scientific Linux on our \hpc so that it can be used there. Porting
+(e.g., \operatingsystembase on our \hpc) so that it can be used there. Porting
 implies some degree of effort, but not nearly as much as redeveloping the
 program in the new environment.  It all depends on how ``portable'' you wrote
 your code.
@@ -55,7 +56,7 @@ end-user.
 \section{Compiling and building on the \hpc}
 
 Compiling refers to the process of translating code written in some programming
-language, e.g. Fortran, C, or C++, to machine code. Building is similar, but
+language, e.g., Fortran, C, or C++, to machine code. Building is similar, but
 includes gluing together the machine code resulting from different source files
 into an executable (or library). The text below guides you through some basic
 problems typical for small software projects. For larger projects it is more
@@ -86,7 +87,7 @@ qsub: waiting for job %\jobid% to start
 
 \subsection{Compiling a sequential program in C}
 
-Go to the examples for Chapter 9 and load the GCC modules:
+Go to the examples for \autoref{ch:compiling-and-testing-your-software-on-the-hpc} and load the GCC modules:
 \begin{prompt}
 %\shellcmd{cd ~/\exampledir}%
 %\shellcmd{module load GCC}%
@@ -125,7 +126,7 @@ total 512
 \end{prompt}
 
 A new file ``hello'' has been created. Note that this file has ``execute''
-rights, i.e. it is an executable. More often than not, calling gcc -- or any
+rights, i.e., it is an executable. More often than not, calling gcc -- or any
 other compiler for that matter -- will provide you with a list of errors and
 warnings referring to mistakes the programmer made, such as typos, syntax
 errors. You will have to correct them first in order to make the code compile.
@@ -218,22 +219,22 @@ It seems to work, now run it on the \hpc.
 %\shellcmd{qsub mpihello.pbs}%
 \end{prompt}
 
-\subsection{Compiling a parallel program in INTEL Cluster Studio}
+\subsection{Compiling a parallel program in Intel Parallel Studio Cluster Edition}
 
-We will now compile the same program, but using the INTEL Cluster Studio
-compilers. We stay in the examples directory for this chapter:
+We will now compile the same program, but using the Intel Parallel Studio
+Cluster Edition compilers. We stay in the examples directory for this chapter:
 
 \begin{prompt}
 %\textbf{cd \tilde/\exampledir}%
 \end{prompt}
 
-We will compile this C/MPI -file into an executable with the INTEL Cluster
-Studio compiler. First, clear the modules (purge) and then load the latest
-``ictce'' (Intel Cluster Toolkit Compiler Edition) module:
+We will compile this C/MPI -file into an executable with the Intel Parallel Studio
+Cluster Edition. First, clear the modules (purge) and then load the latest
+``intel'' module:
 
 \begin{prompt}
 %\shellcmd{module purge}%
-%\shellcmd{module load ictce}%
+%\shellcmd{module load intel}%
 \end{prompt}
 
 Then, compile and list the contents of the directory again. The ictce
@@ -258,11 +259,11 @@ It seems to work, now run it on the \hpc.
 %\shellcmd{qsub mpihello.pbs}%
 \end{prompt}
 
-Note: The \association only has a license for the Intel Cluster Studio for a
+Note: The \association only has a license for the Intel Parallel Studio Cluster Edition for a
 fixed number of users. As such, it might happen that you have to wait a few
 minutes before a floating license becomes available for your use.
 
-Note: The Intel Cluster Studio contains equivalent compilers for all GNU
+Note: The Intel Parallel Studio Cluster Edition contains equivalent compilers for all GNU
 compilers. Hereafter the overview for C, C++ and Fortran compilers.
 
 \begin{tabular}{|p{0.15\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|p{0.15\textwidth}|} \hline

--- a/intro-HPC/ch_fine_tuning_job_specifications.tex
+++ b/intro-HPC/ch_fine_tuning_job_specifications.tex
@@ -1,17 +1,18 @@
 \chapter{Fine-tuning Job Specifications}
+\label{ch:fine-tuning-job-specifications}
 
 As \hpc systemadministrators, we often observe that the \hpc resources are
 not optimally (or wisely) used. For example, we regularly notice that several
 cores on a computing node are not utilized, due to the fact that one sequential
 program uses only one core on the node. Or users run I/O intensive applications
-on nodes with `slow' network connections.
+on nodes with ``slow'' network connections.
 
 Users often tend to run their jobs without specifying specific PBS Job
 parameters.  As such, their job will automatically use the default parameters,
 which are not necessarily (or rarely) the optimal ones.  This can slow down the
 runtime of your application, but also block \hpc resources for other users.
 
-Specifying the `optimal' Job Parameters requires some knowledge of your
+Specifying the ``optimal'' Job Parameters requires some knowledge of your
 application (e.g., how many parallel threads does my application uses, is there
 a lot of inter-process communication, how much memory does my application need)
 and also some knowledge about the \hpc infrastructure (e.g., what kind of
@@ -79,7 +80,7 @@ of an application. Of course, a margin of 10\% to 20\% can be taken to be on
 the safe side.
 
 It is also wise to check the walltime on different compute nodes or to select
-the ''slowest'' compute node for your walltime tests. Your estimate should
+the ``slowest'' compute node for your walltime tests. Your estimate should
 appropriate in case your application will run on the ``slowest'' (oldest)
 compute nodes.
 
@@ -104,14 +105,14 @@ amount of memory an application will use during execution is often non-trivial,
 especially when one uses third-party software.
 
 The ``eat\_mem'' application just consumes and then releases memory, for the
-purpose of this test. It has one parameter, the amount of Gigabits of memory
+purpose of this test. It has one parameter, the amount of gigabytes of memory
 which needs to be allocated.
 
-First compile the program on your machine and then test it for 1 Gb:
+First compile the program on your machine and then test it for 1 GB:
 \begin{prompt}
 %\shellcmd{gcc -o eat\_mem eat\_mem.c}%
 %\shellcmd{./eat\_mem 1}%
-Consuming 1 Gigabit of memory.
+Consuming 1 gigabyte of memory.
 \end{prompt}
 
 
@@ -133,10 +134,10 @@ Total:          32052   8957  23094
 \end{prompt}
 
 Important is to note the total amount of memory available in the machine (i.e.,
-16Gb in this example) and the amount of used and free memory (i.e. 4,7 Gb is
-used and another 11,2 Gb is free here).
+16 GB in this example) and the amount of used and free memory (i.e., 4.7 GB is
+used and another 11.2 GB is free here).
 
-It is not a good practice to use Swap-space for your computational
+It is not a good practice to use swap-space for your computational
 applications. A lot of ``swapping'' can increase the execution time of your
 application tremendously.
 
@@ -162,7 +163,7 @@ Starting a program to monitor is very straightforward; you just add the
 \begin{prompt}
 %\shellcmd{monitor ./eat\_mem 3}%
 time (s) size (kb) %\%%mem %\%%cpu
-Consuming 3 Gigabit of memory.
+Consuming 3 gigabyte of memory.
 5  252900 1.4 0.6
 10  498592 2.9 0.3
 15  743256 4.4 0.3
@@ -187,15 +188,15 @@ Whereby:
 \item  The first column shows you the elapsed time in seconds. By default, all
   values will be displayed every 5 seconds.
 \item  The second column shows you the used memory in kb. We note that the
-  memory slowly increases up to 3 Gb (=  kb), and is released again.
+  memory slowly increases up to 3 GB (= 3072 KB), and is released again.
 \item  The third column shows the memory utilization, expressed in percentages
-  of the full available memory.  At full memory consumption, 19,2\% of the
+  of the full available memory.  At full memory consumption, 19.2\% of the
   memory was being used by our application. With the \emph{``free''} command,
-  we have previously seen that we had a node of 16Gb in this example. 3Gb is
-  indeed more or less 19,2\% of the full available memory.
+  we have previously seen that we had a node of 16 GB in this example. 3 GB is
+  indeed more or less 19.2\% of the full available memory.
 \item  The fourth column shows you the CPU utilization, expressed in
   percentages of a full CPU load. As there are no computations done in our
-  exercise, the value remains very low (i.e. 0.2\%).
+  exercise, the value remains very low (i.e., 0.2\%).
 \end{enumerate}
 
 Monitor will write the CPU usage and memory consumption of simulation to standard error.
@@ -206,7 +207,7 @@ convenient to use a log file. The latter can be specified as follows:
 
 \begin{prompt}
 %\shellcmd{monitor -l test1.log eat\_mem 2}%
-Consuming 2 Gigabit of memory.
+Consuming 2 gigabyte of memory.
 %\shellcmd{cat test1.log}%
 \end{prompt}
 
@@ -217,7 +218,7 @@ cover a minute:
 
 \begin{prompt}
 %\shellcmd{monitor -l test2.log -n 12 eat\_mem 4}%
-Consuming 4 Gigabit of memory.
+Consuming 4 gigabyte of memory.
 \end{prompt}
 
 Note that this option is only available when monitor writes its metrics to a
@@ -228,7 +229,7 @@ specifying delta, the sample rate:
 
 \begin{prompt}
 %\shellcmd{monitor -d 1 ./eat\_mem}%
-Consuming 3 Gigabit of memory.
+Consuming 3 gigabyte of memory.
 \end{prompt}
 
 Monitor will now print the program's metrics every second. Note that the
@@ -287,7 +288,6 @@ or on the command line
 %\shellcmd{qsub -l pmem=2gb}%
 \end{prompt}
 
-In this example, you request 8Gb of memory in total on the node.
 
 \section{Specifying processors requirements}
 
@@ -351,7 +351,7 @@ or with equivalent parameters on the command line
 %\shellcmd{qsub -l nodes=N:ppn=M}%
 \end{prompt}
 
-In this example, you request 8Gb of memory in total on the node.
+In this example, you request 8 GB of memory in total on the node.
 
 This specifies the number of nodes (nodes=N) and the number of processors per
 node (ppn=M) that the job should use. PBS treats a processor core as a
@@ -364,7 +364,7 @@ time.
 \subsection{Monitoring the CPU-utilization}
 
 The previously used ``monitor'' tool also shows the overall CPU-load. The
-``eat\_cpu'' program performs a multiplication of 2 randomly filled a 1500x1500
+``eat\_cpu'' program performs a multiplication of 2 randomly filled a $1500 \times 1500$
 matrices and is just written to consumes a lot of ``\emph{cpu}''.
 
 We first load the monitor modules, study the ``eat\_cpu.c'' program and compile it:
@@ -393,13 +393,13 @@ We notice that it the program keeps its CPU nicely busy at 100\%.
 Some processes spawn one or more sub-processes. In that case, the metrics shown
 by monitor are aggregated over the process and all of its sub-processes
 (recursively). The reported CPU usage is the sum of all these processes, and
-can thus exceed 100 \%.
+can thus exceed 100\%.
 
 Some (well, since this is a \hpc Cluster, we hope most) programs use more
 than one core to perform their computations. Hence, it should not come as a
-surprise that the CPU usage is reported as larger than 100 \%. When programs of
-this type are running on a computer with n cores, the CPU usage can go up to n
-x 100 \%.
+surprise that the CPU usage is reported as larger than 100\%. When programs of
+this type are running on a computer with n cores, the CPU usage can go up to $\text{n}
+\times 100\%$.
 
 This could also be monitored with the \strong{\emph{htop}} command:
 \begin{prompt}
@@ -430,7 +430,7 @@ understanding your overall CPU usage pattern.
 It is good practice to perform a number of runtime stress tests, and to check
 the CPU utilization of your nodes. We (and all other users of the \hpc) would
 appreciate that you use the maximum of the CPU resources that are assigned to
-you and make sure that there are no CPU's in your node who are not utilized
+you and make sure that there are no CPUs in your node who are not utilized
 without reasons.
 
 But how can you maximize?
@@ -439,7 +439,7 @@ But how can you maximize?
 \item  Configure your software. (e.g., to exactly use the available amount of processors in a node)
 \item  Develop your parallel program in a smart way.
 \item  Demand a specific type of compute node (e.g., Harpertown, Westmere), which have a specific number of cores.
-\item  Correct your request for CPU's in your job-script.
+\item  Correct your request for CPUs in your job-script.
 \end{enumerate}
 
 \section{The system load}
@@ -470,7 +470,7 @@ CPUs are always busy and, yet, no process ever waits for one, is \strong{the
 average matching the number of CPUs}.  Your load should not exceed the number
 of cores available.  E.g., if there are four CPUs on a machine and the reported
 one-minute load average is 4.00, the machine has been utilizing its processors
-perfectly for the last 60 seconds. The "100\% utilization" mark is 1.0 on a
+perfectly for the last 60 seconds. The ``100\% utilization'' mark is 1.0 on a
 single-core system, 2.0 on a dual-core, 4.0 on a quad-core, etc. The optimal
 load shall be between 0.7 and 1.0 per processor.
 
@@ -491,8 +491,8 @@ same time depends on the type of the applications that you are running.
 \begin{enumerate}
 \item  When you are running \strong{computational intensive applications}, one
   application per processor will generate the optimal load.
-\item  For \strong{IO intensive applications} (e.g., applications with perform
-  a lot of disk-IO), a higher number of applications can generate the optimal
+\item  For \strong{I/O intensive applications} (e.g., applications which perform
+  a lot of disk-I/O), a higher number of applications can generate the optimal
   load. While some applications are reading or writing data on disks, the
   processors can serve other applications.
 \end{enumerate}
@@ -537,7 +537,7 @@ You can also read it in the \strong{htop} command.
 It is good practice to perform a number of runtime stress tests, and to check
 the system load of your nodes. We (and all other users of the \hpc) would
 appreciate that you use the maximum of the CPU resources that are assigned to
-you and make sure that there are no CPU's in your node who are not utilized
+you and make sure that there are no CPUs in your node who are not utilized
 without reasons.
 
 But how can you maximize?
@@ -547,12 +547,12 @@ But how can you maximize?
 \item  Configure your software (e.g., to exactly use the available amount of processors in a node).
 \item  Develop your parallel program in a smart way, so that it fully utilizes the available processors.
 \item  Demand a specific type of compute node (e.g., Harpertown, Westmere), which have a specific number of cores.
-\item  Correct your request for CPU's in your job-script.
+\item  Correct your request for CPUs in your job-script.
 \end{enumerate}
 
 And then check again.
 
-\section{Checking File sizes \& Disk IO}
+\section{Checking File sizes \& Disk I/O}
 
 \subsection{Monitoring File sizes during execution}
 
@@ -560,8 +560,8 @@ Some programs generate intermediate or output files, the size of which may also
 be a useful metric.
 
 Remember that your available disk space on the \hpc online storage is limited,
-and that you 3 environment variables which point to these directories available
-(i.e. \emph{\$VSC\_DATA}, \emph{\$VSC\_SCRATCH} and \emph{\$VSC\_DATA}).
+and that you have environment variables which point to these directories available
+(i.e., \emph{\$VSC\_DATA}, \emph{\$VSC\_SCRATCH} and \emph{\$VSC\_DATA}).
 On top of those, you can also access some temporary storage (i.e., the /tmp
 directory) on the compute node, which is defined by the
 \emph{\$VSC\_SCRATCH\_LOCAL} environment variable.
@@ -590,13 +590,13 @@ time (s) size (kb) %\%%mem %\%%cpu
 %\dots%
 \end{prompt}
 
-Here, the size of the file `\emph{test.txt}' in directory \$VSC\_SCRATCH will
+Here, the size of the file ``\emph{test.txt}'' in directory \$VSC\_SCRATCH will
 be monitored. Files can be specified by absolute as well as relative path, and
-multiple files are separated by ','.
+multiple files are separated by ``,''.
 
 It is important to be aware of the sizes of the file that will be generated, as
-the available disk space for each user is limited.  We refer to Chapter 6.5 on
-``Quota's'' to check your quota and tools to find which files consumed the
+the available disk space for each user is limited.  We refer to \autoref{sect:how-much-disk-space-do-i-get} on
+``Quotas'' to check your quota and tools to find which files consumed the
 ``quota''.
 
 Several actions can be taken, to avoid storage problems:
@@ -605,13 +605,13 @@ Several actions can be taken, to avoid storage problems:
 \item  Be aware of all the files that are generated by your program. Also check out the hidden files.
 \item  Check your quota consumption regularly.
 \item  Clean up your files regularly.
-\item  First work (i.e. read and write) with your big files in the local /tmp directory. Once finished, you can move your files once to the VSC\_DATA directories.
+\item  First work (i.e., read and write) with your big files in the local /tmp directory. Once finished, you can move your files once to the VSC\_DATA directories.
 \item  Make sure your programs clean up their temporary files after execution.
 \item  Move your output results to your own computer regularly.
 \item  Anyone can request more disk space to the \hpc staff, but you will have to duly justify your request.
 \end{enumerate}
 
-\subsection{Monitoring Disk IO}
+\subsection{Monitoring Disk I/O}
 
 If your Linux system gets slow down due to heavy disk I/O activities, you
 probably want to know which processes or users (in case of multi-user systems)
@@ -670,7 +670,7 @@ The parameter to add in your job-script would be:
 #PBS -l ib
 \end{prompt}
 
-If for some other reasons, a user is fine with the Gigabit Ethernet network, he
+If for some other reasons, a user is fine with the gigabit Ethernet network, he
 can specify:
 
 \begin{prompt}
@@ -681,7 +681,7 @@ can specify:
 
 \subsection{Command Lines arguments}
 
-Many programs, e.g., matlab, take command line options. To make sure these do
+Many programs, e.g., MATLAB, take command line options. To make sure these do
 not interfere with those of monitor and vice versa, the program can for
 instance be started in the following way:
 
@@ -689,7 +689,7 @@ instance be started in the following way:
 %\shellcmd{monitor -delta 60 -- matlab -nojvm -nodisplay computation.m}%
 \end{prompt}
 
-The use of '--' will ensure that monitor does not get confused by matlab's '-nojvm' and '-nodisplay' options.
+The use of ``--'' will ensure that monitor does not get confused by MATLAB's '-nojvm' and '-nodisplay' options.
 
 \subsection{Exit Code}
 
@@ -705,7 +705,7 @@ environment variable MONITOR\_EXIT\_ERROR to a more suitable value.
 
 \subsection{Monitoring a running process}
 
-It is also possible to "attach" monitor to a program or process that is already
+It is also possible to ``attach'' monitor to a program or process that is already
 running. One simply determines the relevant process ID using the ps command,
 e.g., 18749, and starts monitor:
 

--- a/intro-HPC/ch_good_practices.tex
+++ b/intro-HPC/ch_good_practices.tex
@@ -1,4 +1,5 @@
 \chapter{Good Practices}
+\label{ch:good-practices}
 
 \begin{enumerate}
 
@@ -23,7 +24,7 @@
   \item  Try to benchmark the software for scaling issues when using MPI or for
     I/O issues.
 
-  \item  Use the Scratch drive (\$VSC\_SCRATCH\_NODE which is mapped to the
+  \item  Use the scratch file system (\$VSC\_SCRATCH\_NODE which is mapped to the
     local /tmp) whenever possible. Local disk I/O is always much faster as it
     does not have to use the network.
 
@@ -50,7 +51,7 @@
 
   \item  For all parallel computing, request to use ``Infiniband''.
 
-  \item  And above all\dots do not hesitate to contact the \hpc staff. We're
+  \item  And above all \dots\ do not hesitate to contact the \hpc staff. We're
     here to help you.
 \end{enumerate}
 

--- a/intro-HPC/ch_introduction.tex
+++ b/intro-HPC/ch_introduction.tex
@@ -11,7 +11,7 @@ processing capacity -- particularly speed of calculation and available memory.
 While the supercomputers in the early days (around 1970) used only a few
 processors, in the 1990s machines with thousands of processors began to appear
 and, by the end of the 20th century, massively parallel supercomputers with
-tens of thousands of "off-the-shelf" processors were the norm. A large number
+tens of thousands of ``off-the-shelf'' processors were the norm. A large number
 of dedicated processors are placed in close proximity to each other in a
 computer cluster.
 
@@ -37,14 +37,14 @@ and gas exploration, molecular modeling (computing the structures and
 properties of chemical compounds, biological macromolecules, polymers, and
 crystals), and physical simulations (such as simulations of the early moments
 of the universe, airplane and spacecraft aerodynamics, the detonation of
-nuclear weapons, and nuclear fusion). \footnote{ $ Wikipedia$ }
+nuclear weapons, and nuclear fusion).\footnote{Wikipedia}
 
 \section{What is the \hpc?}
 \label{sec:what-is-the-hpc}
 
 The \hpc is a collection computers with Intel processors, running a Linux
 operating system, shaped in the form of lunch boxes and stored above and next
-to each other in racks, interconnected with fiber lines. Their number crunching
+to each other in racks, interconnected with copper and fiber lines. Their number crunching
 power is (presently) measured in hundreds of billions of floating point
 operations (gigaflops) and even in Teraflops.
 
@@ -56,18 +56,23 @@ The \hpc relies on parallel-processing technology to offer \university researche
 extremely fast solution for all their data processing needs.
 
 The \hpc consists of:
+
 \ifantwerpen
+\begin{center}
 \begin{tabular}{|p{1.8in}|p{2.1in}|} \hline
-\strong{In technical terms}         & \strong{\dots  in human terms}                    \\ \hline
-168 nodes and 2496 cores            & \dots  or the equivalent of 612 quad-core PC's    \\ \hline
-22.5 Terabyte of online storage     & \dots  or the equivalent of 5600 DVD's            \\ \hline
-10Gbit infiniband Fiber connections & \dots  or allowing to transfer 2 DVD's per second \\ \hline
+\strong{In technical terms}         & \strong{\dots\  in human terms}                    \\ \hline
+336 nodes and 4992 cores            & \dots\  or the equivalent of 1248 quad-core PCs    \\ \hline
+100 Terabyte of online storage     & \dots\  or the equivalent of over 20000 DVDs            \\ \hline
+up to 40 Gbit infiniband fiber connections & \dots\  or allowing to transfer 8 DVDs per second \\ \hline
 \end{tabular}
+\end{center}
 \fi
 %TODO insert specs for other sites
 
-The \hpc currently has:
+The \hpc currently consists of:
+
 \ifantwerpen
+Turing:
   \begin{enumerate}
     \item  64 compute nodes with 2 quad core Harpertown processors, 16 GB memory,
            120 GB local disk, GbE network
@@ -77,6 +82,13 @@ The \hpc currently has:
            120 GB local disk, QDR-IB network
     \item  8 nodes with 2 six core Westmere processors, 24 GB memory,
            120 GB local disk, GbE network
+  \end{enumerate}
+and Hopper:
+  \begin{enumerate}
+    \item  96 compute nodes with 2 ten core Ivy Bridge processors, 64 GB memory,
+           500 GB local disk, FDR10 network
+    \item  24 nodes with 2 ten core Harpertown processors, 64 GB memory,
+           500 GB local disk, FDR10 network
   \end{enumerate}
 \fi
 \ifleuven
@@ -94,9 +106,9 @@ The \hpc currently has:
 %TODO insert specs for other sites
 
 \ifantwerpen
-All the nodes in the \hpc run under the ``\operatingsystem'' operating
-system, which is a clone of ``Red Hat Enterprise Linux (RHEL) 5'', with a
-``2.6.18'' kernel with \emph{cpuset} support and \emph{BLCR} modules.
+All the nodes in the \hpc run under the ``\operatingsystemSL'' operating
+system, which is a clone of ``\operatingsystemRHEL'', 
+with \emph{cpuset} support and \emph{BLCR} modules.
 \fi
 \ifleuven
 All the nodes in the \hpc run under the ``\operatingsystem'' operating system, version 6.
@@ -109,7 +121,7 @@ Two tools perform the \strong{job management} and \strong{job scheduling}:
   \item  Moab: job scheduler and management tools.
 \end{enumerate}
 \ifantwerpen
-\strong{Accounting} is handled by a third tool, i.e., GOLD.
+%\strong{Accounting} is handled by a third tool, i.e., GOLD.
 \fi
 \ifleuven
 \strong{Accounting} is handled by a third tool, i.e., MAM (Moab Accounting Manager).
@@ -120,22 +132,17 @@ For maintenance and monitoring, we use:
 \ifantwerpen
     \begin{enumerate}
       \item  Ganglia: monitoring software;
-      \item  Nagios: alert manager.
+      \item  Icinga: alert manager.
     \end{enumerate}
 \fi
 \ifleuven
     \begin{enumerate}
       \item  Ganglia: monitoring software;
-      \item  Nagios: alert manager.
+      \item  Icinga: alert manager.
     \end{enumerate}
 \fi
 %TODO check tools for other sites
 
-\ifantwerpen
-The \hpc is physically located at the Groenenborger Campus and is accessible
-through the University Network from all \university sites. There are 4 staff members
-available to support the researchers with the utilization of the \hpc.
-\fi
 
 \section{What is the \hpc not!}
 \label{sec:what-is-the-hpc-not}
@@ -204,11 +211,11 @@ sweep). This is another form of running your sequential programs in parallel.
 
 You can use \emph{any} programming language, \emph{any} software package and
 \emph{any} library provided it has a version that runs on Linux, specifically,
-on the version of Linux that is installed on the compute nodes, \operatingsystem.
+on the version of Linux that is installed on the compute nodes, \operatingsystembase.
 
 For the most common \strong{programming languages}, a compiler is available on
 \operatingsystem. Supported and common programming languages on the \hpc are
-C/C++, FORTRAN, Java, Python, MATLAB, R, etc.
+C/C++, FORTRAN, Java, Perl, Python, MATLAB, R, etc.
 
 Supported and commonly used compilers are GCC, clang, J2EE and Intel Cluster
 Studio.
@@ -216,7 +223,7 @@ Studio.
 Commonly used software packages are ABINIT, CP2K, Gaussian, Gromacs, Molpro,
 NWChem, Quantum Espresso, R, Siesta, TURBOMOLE, WIEN2k,\ldots
 
-Commonly used Libraries are Intel MKL, FFTW, HDF5, PETSc and M(VA)PICH/OpenMPI.
+Commonly used Libraries are Intel MKL, FFTW, HDF5, PETSc and Intel MPI, M(VA)PICH, OpenMPI.
 
 Additional software can be installed ``\emph{on demand}''. Please check the
 \hpc staff to see whether the \hpc can handle your specific requirements.
@@ -224,12 +231,11 @@ Additional software can be installed ``\emph{on demand}''. Please check the
 \subsection{What operating systems can I use?}
 \label{sec:what-operating-systems-can-i-use}
 
-All nodes in the \hpc cluster run under the ``Scientific Linux'' (SL)
-Operating system, which is a specific version of RedHat-Linux. This means that
-all programs (executable) must be compiled for the SL Operating System.
+All nodes in the \hpc cluster run under \operatingsystemSL, which is a specific version of \operatingsystemRHEL. This means that
+all programs (executable) must be compiled for \operatingsystemSL.
 
 But a user can connect from any desk computer in the \university network to the \hpc,
-regardless of the Operating System that he is using at his personal computer.
+regardless of the Operating System that he is using on his personal computer.
 The user can use any of the common Operating Systems (such as Windows, OS X or
 any version of Linux/Unix/BSD) and run and control his programs on the \hpc.
 
@@ -241,8 +247,8 @@ knowledge is explained in this tutorial.
 
 When you think that the \hpc is a useful tool to support your computational
 needs, we encourage you to acquire a VSC-account (as explained in
-\autoref{ch:getting-a-hpc-account}), read \autoref{ch:setting-up-the-environment}, "Setting up the
-environment", and explore Chapters 5 to 11 which will help you to transfer and
+\autoref{ch:getting-a-hpc-account}), read \autoref{ch:preparing-the-environment}, ``Setting up the
+environment'', and explore chapters~\ref{ch:running-interactive-jobs} to~\ref{ch:fine-tuning-job-specifications} which will help you to transfer and
 run your programs on the \hpc cluster.
 
 Do not hesitate to contact the \hpc team members for any help.

--- a/intro-HPC/ch_multi_core_jobs.tex
+++ b/intro-HPC/ch_multi_core_jobs.tex
@@ -1,4 +1,5 @@
 \chapter{Multi core jobs/Parallel Computing}
+\label{ch:multi-core-jobs-parallel-computing}
 
 \section{Why Parallel Programming?}
 
@@ -19,7 +20,7 @@ There are two important motivations to engage in parallel programming.
 
 On a desktop computer, this enables a user to run multiple programs and the
 operating system simultaneously. For scientific computing, this means you have
-th ability in principle of splitting up your computations into groups and
+the ability in principle of splitting up your computations into groups and
 running each group on its own core.
 
 There are multiple different ways to achieve parallel programming. The table
@@ -31,12 +32,12 @@ common approaches: (raw) threads, OpenMP and MPI.
 \begin{tabular}{|p{0.15\textwidth}|p{0.3\textwidth}|p{0.55\textwidth}|} \hline
 \multicolumn{3}{|c|}{\strong{Parallel programming approaches}} \\ \hline
 \strong{Tool}                                                          & \strong{Available language bindings}                                   & \strong{Limitations} \\ \hline
-Raw threads\newline pthreads, boost::\newline threading, \dots         & Threading libraries are available for all common programming languages & Threads are limited to a shared memory systems. They are more often used on single node systems rather than for \hpc. Thread management is hard. \\ \hline
-OpenMP                                                                 & Fortran/C/C++                                                      & Limited to shared memory systems, but large shared memory systems for \hpc are not uncommon (e.g. SGI UV). Loops and task can be parallelized by simple insertion of compiler directives. Under the hood threads are used. Hybrid approaches exist which use OpenMP to parallelize the work load on each node and MPI (see below) for communication between nodes. \\ \hline
+Raw threads\newline pthreads, boost::\newline threading, \dots         & Threading libraries are available for all common programming languages & Threads are limited to shared memory systems. They are more often used on single node systems rather than for \hpc. Thread management is hard. \\ \hline
+OpenMP                                                                 & Fortran/C/C++                                                      & Limited to shared memory systems, but large shared memory systems for HPC are not uncommon (e.g., SGI UV). Loops and task can be parallelized by simple insertion of compiler directives. Under the hood threads are used. Hybrid approaches exist which use OpenMP to parallelize the work load on each node and MPI (see below) for communication between nodes. \\ \hline
 Lightweight threads with clever scheduling, Intel TBB, Intel Cilk Plus & C/C++                                                                & Limited to shared memory systems, but may be combined with MPI. Thread management is taken care of by a very clever scheduler enabling the programmer to focus on parallelization itself. Hybrid approaches exist which use TBB and/or Cilk Plus to parallelize the work load on each node and MPI (see below) for communication between nodes. \\ \hline
 MPI                                                                    & Fortran/C/C++ Python                                             & Applies to both distributed and shared memory systems. Cooperation between different nodes or cores is managed by explicit calls to library routines handling communication routines. \\ \hline
 Global Arrays library                                                  & C/C++ Python                                                       & Mimics a global address space on distributed memory systems, by distributing arrays over many nodes and one sided communication. This library is used a lot for chemical structure calculation codes and was used in one of the first applications that broke the PetaFlop barrier. \\ \hline
-Scoop                                                                  & Python                                                                 & Applies to both shared and distributed memory system. Not extremely advanced, but may present a quick road to parallelization of python code.  \\ \hline
+Scoop                                                                  & Python                                                                 & Applies to both shared and distributed memory system. Not extremely advanced, but may present a quick road to parallelization of Python code.  \\ \hline
 \end{tabular}
 
 \section{Parallel Computing with threads}
@@ -69,7 +70,7 @@ threads that are assigned to multiple processing cores) is that you can achieve
 big speedups, as all cores of your CPU (and all CPUs if you have more than one)
 are used at the same time.
 
-Here is a simple example program that spawns 7 threads, where each one runs a
+Here is a simple example program that spawns 5 threads, where each one runs a
 simple function that only prints ``Hello from thread''.
 
 Go to the example directory:
@@ -119,10 +120,12 @@ Hello from thread 4!
 \end{prompt}
 
 % FIXME: Refer to Hager & co insted of this.
-\underbar{Tip:} If you plan engaging in parallel programming using threads,
+\begin{tip}
+If you plan engaging in parallel programming using threads,
 this book may prove useful: \emph{Professional Multicore Programming: Design
 and Implementation for C++ Developers. Cameron Hughes and Tracey Hughes. Wrox
 2008.}
+\end{tip}
 
 \section{Parallel Computing with OpenMP}
 
@@ -131,7 +134,7 @@ memory form of parallelism. It uses a set of compiler directives (statements
 that you add to your code and that are recognized by your Fortran/C/C++
 compiler if OpenMP is enabled or otherwise ignored) that are incorporated at
 compile-time to generate a multi-threaded version of your code. You can think
-of Pthreads (above) as doing multi-threaded programming "by hand", and OpenMP
+of Pthreads (above) as doing multi-threaded programming ``by hand'', and OpenMP
 as a slightly more automated, higher-level API to make your program
 multithreaded. OpenMP takes care of many of the low-level details that you
 would normally have to implement yourself, if you were using Pthreads from the
@@ -164,8 +167,8 @@ int var1, var2, var3;
 \subsection{Private versus Shared variables}
 
 By using the private() and shared() clauses, you can specify variables within
-the parallel region as being \strong{shared}, i.e. visible and accessible by
-all threads simultaneously, or \strong{private}, i.e. private to each thread,
+the parallel region as being \strong{shared}, i.e., visible and accessible by
+all threads simultaneously, or \strong{private}, i.e., private to each thread,
 meaning each thread will have its own local copy. In the code example below for
 parallelizing a for loop, you can see that we specify the thread\_id and nloops
 variables as private.
@@ -211,9 +214,9 @@ Thread 6 performed 125 iterations of the loop.
 
 \subsection{Critical Code}
 
-Using OpenMP you can specify something called a "critical" section of code.
+Using OpenMP you can specify something called a ``critical'' section of code.
 This is code that is performed by all threads, but is only performed
-\strong{one thread at a time} (i.e. in serial). This provides a convenient way
+\strong{one thread at a time} (i.e., in serial). This provides a convenient way
 of letting you do things like updating a global variable with local results
 from each thread, and you don't have to worry about things like other threads
 writing to that global variable at the same time (a collision).
@@ -257,9 +260,9 @@ Total # loop iterations is 100000
 
 Reduction refers to the process of combining the results of several
 sub-calculations into a final result. This is a very common paradigm (and
-indeed the so-called "map-reduce" framework used by Google and others is very
+indeed the so-called ``map-reduce'' framework used by Google and others is very
 popular). Indeed we used this paradigm in the code example above, where we used
-the "critical code" directive to accomplish this. The map-reduce paradigm is so
+the ``critical code'' directive to accomplish this. The map-reduce paradigm is so
 common that OpenMP has a specific directive that allows you to more easily
 implement this.
 
@@ -269,6 +272,7 @@ And compile it (whilst including the ``\emph{openmp}'' library) and run and
 test it on the login-node:
 
 \begin{prompt}
+%\shellcmd{module load GCC}%
 %\shellcmd{gcc -fopenmp -o omp3 omp3.c}%
 %\shellcmd{./omp3}%
 Total # loop iterations is 100000
@@ -293,20 +297,22 @@ Some other clauses of interest are:
 \item  nowait: threads will not wait until everybody is finished
 \item  schedule(type, chunk) allows you to specify how tasks are spawned out to threads in a for loop. There are three types of scheduling you can specify
 \item  if: allows you to parallelize only if a certain condition is met
-\item  \dots  and a host of others
+\item  \dots\  and a host of others
 \end{enumerate}
 
-\underbar{Tip:} If you plan engaging in parallel programming using OpenMP, this
+\begin{tip}
+If you plan engaging in parallel programming using OpenMP, this
 book may prove useful: \textit{Using OpenMP - Portable Shared Memory Parallel
 Programming}. By Barbara Chapman Gabriele Jost and Ruud van der Pas Scientific
 and Engineering Computation. 2005.
+\end{tip}
 
-\section{Parallel Computing with MPI }
+\section{Parallel Computing with MPI}
 
 The Message Passing Interface (MPI) is a standard defining core syntax and
 semantics of library routines that can be used to implement parallel
 programming in C (and in other languages as well). There are several
-implementations of MPI such as Open MPI, Intel MPI, M(VA)PICH(2) and LAM/MPI.
+implementations of MPI such as Open MPI, Intel MPI, M(VA)PICH and LAM/MPI.
 
 In the context of this tutorial, you can think of MPI, in terms of its
 complexity, scope and control, as sitting in between programming with Pthreads,
@@ -335,14 +341,21 @@ parallel, across any collection of computers, as long as they are networked
 together. Just make sure to ask permission before you load up your lab-mate's
 computer's CPU(s) with your computational tasks!
 
-Here is a "Hello World" program in MPI written in C. In this example, we send a
-"Hello" message to each processor, manipulate it trivially, return the results
+Here is a ``Hello World'' program in MPI written in C. In this example, we send a
+``Hello'' message to each processor, manipulate it trivially, return the results
 to the main process, and print the messages.
 
 Study the MPI-programme and the PBS-file:
 
 \examplecode{C}{mpi_hello.c}
 \examplecode{bash}{mpi_hello.pbs}
+
+and compile it:
+
+\begin{prompt}
+%\shellcmd{module load intel}%
+%\shellcmd{mpiicc -o mpi\_hello mpi\_hello.c}%
+\end{prompt}
 
 mpiicc is a wrapper of the Intel C++ compiler icc to compile MPI programs (see
 the chapter on compilation for details).
@@ -383,7 +396,7 @@ determining the number of process \emph{ranks} in MPI\_COMM\_WORLD, which is
 an opaque descriptor for communication between the set of processes. A single
 process, multiple data (SPMD = Single Program, Multiple Data) programming model
 is thereby facilitated, but not required; many MPI implementations allow
-multiple, different, executable's to be started in the same MPI job. Each
+multiple, different, executables to be started in the same MPI job. Each
 process has its own rank, the total number of processes in the world, and the
 ability to communicate between them either with point-to-point (send/receive)
 communication, or by collective communication among the group. It is enough for
@@ -402,7 +415,9 @@ size of the world N, so it also seeks to scale to the runtime configuration
 without compilation for each size variation, although runtime decisions might
 vary depending on that absolute amount of concurrency available.
 
-
-\underbar{Tip:} If you plan engaging in parallel programming using MPI, this
+\begin{tip}
+If you plan engaging in parallel programming using MPI, this
 book may prove useful: \emph{Parallel Programming with MPI. Peter Pacheo.
 Morgan Kaufmann. 1996.}
+\end{tip}
+

--- a/intro-HPC/ch_multi_job_submission.tex
+++ b/intro-HPC/ch_multi_job_submission.tex
@@ -1,4 +1,5 @@
 \chapter{Multi-job submission}
+\label{ch:multi-job-submission}
 
 A frequent occurring characteristic of scientific computation is their focus on
 data intensive processing. A typical example is the iterative evaluation of a
@@ -40,9 +41,9 @@ aggregation, i.e., it has to be run once for each instance of the parameter
 values.
 
 However, the Worker Framework's scope is wider: it can be used for any scenario
-that can be reduced to a \strong{MapReduce} approach.\footnote{ MapReduce :
+that can be reduced to a \strong{MapReduce} approach.\footnote{MapReduce:
 `Map' refers to the map pattern in which every item in a collection is mapped
-onto a new value by applying a given function, while `reduce' refers to the
+onto a new value by applying a given function, while ``reduce'' refers to the
 reduction pattern which condenses or reduces a collection of previously
 computed results to a single value.}
 
@@ -87,7 +88,7 @@ However, the user wants to run this program for many parameter instances, e.g.,
 he wants to run the program on 100 instances of temperature, pressure and
 volume.  The 100 parameter instances can be stored in a comma separated value
 file (.csv) that can be generated using a spreadsheet program such as Microsoft
-Excel, and RDBMS or just by hand using any text editor (do \strong{not} use a
+Excel or RDBMS or just by hand using any text editor (do \strong{not} use a
 word processor such as Microsoft Word). The first few lines of the file
 ``\emph{data.csv}'' would look like:
 
@@ -122,8 +123,8 @@ Note that:
 \end{enumerate}
 
 The walltime is calculated as follows: one calculation takes 15 minutes, so 100
-calculations take 1,500 minutes on one CPU. However, this job will use 8 CPUs,
-so the 100 calculations will be done in 1,500/8 = 187,5 minutes, i.e., 4 hours
+calculations take 1500 minutes on one CPU. However, this job will use 8 CPUs,
+so the 100 calculations will be done in 1500/8 = 187.5 minutes, i.e., 4 hours
 to be on the safe side.
 
 The job can now be submitted as follows:
@@ -140,6 +141,12 @@ all computations are done. A computation for such a parameter instance is
 called a work item in Worker parlance.
 
 \section{The Worker framework: Job arrays}
+
+First go to the right directory:
+
+\begin{prompt}
+%\shellcmd{cd ~/\exampledir/job\_array}%
+\end{prompt}
 
 As a simple example, assume you have a serial program called \emph{myprog} that you
 want to run on various input files \textit{input[1-100]}.
@@ -169,8 +176,8 @@ array, where \emph{range} is a range of numbers (e.g., \emph{1-100} or
 The details are
 
 \begin{enumerate}
-\item  a job is submitted for each \emph{number} in the range,
-\item  individuals jobs are referenced as \emph{jobid-number}, and the entire array can be referenced as \emph{jobid} for easy killing etc., and
+\item  a job is submitted for each \emph{number} in the range;
+\item  individuals jobs are referenced as \emph{jobid-number}, and the entire array can be referenced as \emph{jobid} for easy killing etc.; and
 \item  each jobs has \emph{PBS\_ARRAYID} set to its \emph{number} which allows the script/program to specialize for that job
 \end{enumerate}
 
@@ -182,7 +189,7 @@ The job could have been submitted using:
 The effect was that rather than 1 job, the user would actually submit 100 jobs
 to the queue system. This was a popular feature of TORQUE, but as this
 technique puts quite a burden on the scheduler, it is not supported by Moab
-(the current job scheduler) anymore.
+(the current job scheduler).
 
 To support those users who used the feature and since it offers a convenient
 workflow, the ``worker framework'' implements the idea of ``job arrays'' in its
@@ -284,8 +291,8 @@ executes the prologue and epilogue.
 %\shellcmd{cd ~/\exampledir/map\_reduce}%
 \end{prompt}
 
-The script 'pre.sh' prepares the data by creating 100 different input-files,
-and the script 'post.sh' aggregates (concatenates) the data.
+The script ``pre.sh'' prepares the data by creating 100 different input-files,
+and the script ``post.sh'' aggregates (concatenates) the data.
 
 
 First study the scripts:
@@ -329,14 +336,14 @@ Since a Worker job will typically run for several hours, it may be reassuring
 to monitor its progress. Worker keeps a log of its activity in the directory
 where the job was submitted. The log's name is derived from the job's name and
 the job's ID, i.e., it has the form $<$jobname$>$.log$<$jobid$>$. For the
-running example, this could be 'run.pbs.log\jobnumber', assuming the job's ID is
+running example, this could be ``run.pbs.log\jobnumber'', assuming the job's ID is
 \jobnumber. To keep an eye on the progress, one can use:
 
 \begin{prompt}
 %\shellcmd{tail -f run.pbs.log\jobnumber}%
 \end{prompt}
 
-Alternatively, a Worker command that summarizes a log file can be used:
+Alternatively, ``wsummarize'', a Worker command that summarizes a log file, can be used:
 \begin{prompt}
 %\shellcmd{watch -n 60 wsummarize run.pbs.log\jobnumber}%
 \end{prompt}
@@ -366,7 +373,7 @@ Note that it is trivial to set individual time constraints for work items by
 introducing a parameter, and including the values of the latter in the CSV
 file, along with those for the temperature, pressure and volume.
 
-Also note that 'timedrun' is in fact offered in a module of its own, so it can
+Also note that ``timedrun'' is in fact offered in a module of its own, so it can
 be used outside the Worker framework as well.
 
 \subsection{Resuming a Worker job}
@@ -376,7 +383,7 @@ consequently, sometimes the latter is underestimated. When using the Worker
 framework, this implies that not all work items will have been processed.
 Worker makes it very easy to resume such a job without having to figure out
 which work items did complete successfully, and which remain to be computed.
-Suppose the job that did not complete all its work items had ID '445948'.
+Suppose the job that did not complete all its work items had ID ``445948''.
 
 \begin{prompt}
 %\shellcmd{wresume -jobid \jobnumber}%
@@ -403,7 +410,7 @@ reporting a failure. It is also possible to retry work items that failed
 \end{prompt}
 
 By default, a job's prologue is not executed when it is resumed, while its
-epilogue is. 'wresume' has options to modify this default behavior.
+epilogue is. ``wresume'' has options to modify this default behavior.
 
 \subsection{Further information}
 

--- a/intro-HPC/ch_preparing_the_environment.tex
+++ b/intro-HPC/ch_preparing_the_environment.tex
@@ -1,5 +1,5 @@
 \chapter{Preparing the Environment}
-\label{ch:setting-up-the-environment}
+\label{ch:preparing-the-environment}
 
 Before you can really start using the \hpc clusters, there are several things you need to do or know:
 
@@ -59,7 +59,7 @@ logout
 Connection to %\loginnode% closed.
 \end{prompt}
 
-\strong{Tip: Setting your Language right}
+\begin{tip}[Setting your Language right]
 
 You may encounter the following warning message during connecting:
 \begin{prompt}
@@ -73,7 +73,7 @@ LANG = (unset)
 perl: warning: Falling back to the standard locale ("C").
 \end{prompt}
 
-This means that the correct `locale' has not yet been properly specified on your local machine. Try:
+This means that the correct ``locale'' has not yet been properly specified on your local machine. Try:
 
 \begin{prompt}
 %\shellcmd{locale}%
@@ -86,6 +86,7 @@ LC_NUMERIC="C"
 LC_TIME="C"
 LC_ALL=
 \end{prompt}
+\end{tip}
 
 A \strong{locale} is a set of parameters that defines the user's language,
 country and any special variant preferences that the user wants to see in their
@@ -99,19 +100,19 @@ favorite editor and add the following lines:
 %\shellcmd{vi ~/.bash\_profile}%
 %\dots%
 export LANGUAGE="en_US.UTF-8"
-export LC\_ALL="en_US.UTF-8"
-export LC\_CTYPE="en_US.UTF-8"
+export LC_ALL="en_US.UTF-8"
+export LC_CTYPE="en_US.UTF-8"
 export LANG="en_US.UTF-8"
 %\dots%
 \end{prompt}
 
-or alternatively (if you are not comfortable with the Linux editor's):
+or alternatively (if you are not comfortable with the Linux editors):
 
 \begin{prompt}
 %\shellcmd{echo "export LANGUAGE=\textbackslash "en\_US.UTF-8\textbackslash " $>$$>$ ~/.profile"}%
-%\shellcmd{echo ``export LC\_ALL=\textbackslash "en\_US.UTF-8\textbackslash " $>$$>$ ~/.profile''}%
-%\shellcmd{echo ``export LC\_CTYPE=\textbackslash "en\_US.UTF-8\textbackslash " $>$$>$ ~/.profile''}%
-%\shellcmd{echo ``export LANG="en\_US.UTF-8\textbackslash " $>$$>$ ~/.profile''}%
+%\shellcmd{echo "export LC\_ALL=\textbackslash "en\_US.UTF-8\textbackslash " $>$$>$ ~/.profile"}%
+%\shellcmd{echo "export LC\_CTYPE=\textbackslash "en\_US.UTF-8\textbackslash " $>$$>$ ~/.profile"}%
+%\shellcmd{echo "export LANG="en\_US.UTF-8\textbackslash " $>$$>$ ~/.profile"}%
 \end{prompt}
 
 You can now log-out and re-connect to the \hpc, and you should not get these warnings anymore.
@@ -122,10 +123,12 @@ Before you can do some work, you'll have to \strong{transfer the files} that
 you need from your desktop or department to the cluster. At the end of a job,
 you might want to transfer some files back.
 
+\ifmacORlinux
 The preferred way to transfer files is by using an scp or sftp via the secure
-OpenSSH protocol.  OS X comes with its own implementation of OpenSSH, so you
-don't need to install any third-party software to use it. Just open a Terminal
+OpenSSH protocol.  Linux and OS X are shipped with an implementation of OpenSSH, so you
+don't need to install any third-party software to use it. Just open a terminal
 window and jump in!
+\fi
 
 \ifwindows
   \subsection{WinSCP}
@@ -134,21 +137,19 @@ window and jump in!
   which is a graphical ftp-style program (but than one that uses the ssh way of
   communicating with the cluster rather then the less secure ftp) that is also
   freely available. WinSCP can be downloaded both as an installation package and
-  as a standalone portable executable.
-
-  Google ``WinSCP Download'' and download it from \url{http://www.winscp.net}
+  as a standalone portable executable from \url{http://www.winscp.net}
 
   To transfer your files using WinSCP,
 
   \begin{enumerate}
   \item  Open the program
-  \item  Fill in the necessary fields under $<$\emph{Session}$>$
+  \item  Fill in the necessary fields under \keys{Session}
   \begin{enumerate}
-  \item  Press $<$\emph{New}$>$
-  \item  Enter ``\emph{\loginnode}'' in the $<$Host name$>$ field
-  \item  Put your ``\emph{vsc-account}'' in $<$\emph{User name}$>$ field
-  \item  Select your private key in the field $<$\emph{Private key file}$>$.
-  \item  Select $<$\emph{SFTP}$>$ as the $<$\emph{file}$>$ protocol.
+  \item  Press \keys{New}.
+  \item  Enter ``\emph{\loginnode}'' in the \keys{Host name} field.
+  \item  Put your ``\emph{vsc-account}'' in \keys{User name} field.
+  \item  Select your private key in the field \keys{Private key file}.
+  \item  Select \keys{SFTP} as the \keys{file} protocol.
   \item  Note that the password field remains empty.
   \end{enumerate}
   \end{enumerate}
@@ -156,14 +157,14 @@ window and jump in!
   \includegraphics*[width=3.42in, height=3.04in, keepaspectratio=false]{img0214}
 
   \begin{enumerate}
-  \item  By pressing on the $<$\emph{Save}$>$ button, you can save the session under $<$\emph{Stored sessions}$>$ for future access.
-  \item  Finally, when clicking on 'Login', you will be asked for your key passphrase.
+  \item  By pressing on the \keys{Save} button, you can save the session under \keys{Stored sessions} for future access.
+  \item  Finally, when clicking on \keys{Login}, you will be asked for your key passphrase.
   \end{enumerate}
 
   \includegraphics*[width=3.14in, height=2.47in, keepaspectratio=false]{img0215}
 
-  The first time you make the connection, you will be asked to 'Continue
-  connecting and add host key to the cache'; select 'Yes'.
+  The first time you make the connection, you will be asked to ``Continue
+  connecting and add host key to the cache''; select \keys{Yes}.
 
   \includegraphics*[width=5.74in, height=2.81in, keepaspectratio=false]{img0216}
 
@@ -174,10 +175,10 @@ window and jump in!
 \ifmacORlinux
   \subsection{Using scp}
 
-  \strong{Secure copy} or \strong{SCP} is a tool (commando) for securely
+  \strong{Secure copy} or \strong{SCP} is a tool (command) for securely
   transferring files between a local host (= your computer) and a remote host
   (the \hpc). It is based on the Secure Shell (SSH) protocol.  The \strong{scp}
-  command works equivalent `as the \strong{cp}  (i.e. \strong{c}o\strong{p}y)
+  command is the equivalent of the \strong{cp}  (i.e., \strong{c}o\strong{p}y)
   command, but can copy files to or from remote machines.
 
   Open a additional Terminal window and check that you're working on your local machine.
@@ -188,7 +189,7 @@ window and jump in!
   \end{prompt}
 
   If you're still using the terminal that is connected to the \hpc, close the
-  connection by typing "exit" in the terminal window. Alternatively, open a new
+  connection by typing ``exit'' in the terminal window. Alternatively, open a new
   terminal window using the shortcut $<$command$>$$<$N$>$.
 
   For example, we will copy the (local) file ``\emph{localfile.txt}'' to your
@@ -265,18 +266,18 @@ window and jump in!
   %\shellcmd{sftp $<$vsc-account$>$@$<$vsc-login node$>$}%
   \end{prompt}
 
-  Typical and popular commando's inside an sftp session are:
+  Typical and popular commands inside an sftp session are:
 
   \begin{tabular}{|p{0.3\textwidth}|p{0.6\textwidth}|} \hline
-  \strong{cd \tilde/examples/fibo} & Move to the examples/fibo subdirectory on the \hpc (i.e. the remote machine)\\  \hline
+  \strong{cd \tilde/examples/fibo} & Move to the examples/fibo subdirectory on the \hpc (i.e., the remote machine)\\  \hline
   \strong{ls}                      & Get a list of the files in the current directory on the \hpc. \\ \hline
-  \strong{get fibo.py}             & Copy the file `fibo.py' from the \hpc \\ \hline
-  \strong{get tutorial/HPC.pdf}    & Copy the file `HPC.pdf' from the \hpc, which is in the `tutorial' subdirectory. \\ \hline
-  \strong{lcd test}                & Move to the `test' subdirectory on your local machine. \\ \hline
+  \strong{get fibo.py}             & Copy the file ``fibo.py'' from the \hpc \\ \hline
+  \strong{get tutorial/HPC.pdf}    & Copy the file ``HPC.pdf'' from the \hpc, which is in the ``tutorial'' subdirectory. \\ \hline
+  \strong{lcd test}                & Move to the ``test'' subdirectory on your local machine. \\ \hline
   \strong{lcd ..}                  & Move up one level in the local directory. \\ \hline
   \strong{lls}                     & Get local directory listing \\ \hline
   \strong{put test.py}             & Copy the local file test.py to the \hpc. \\ \hline
-  \strong{put test1.py test2.py }  & Copy the local file test1.py to the \hpc and rename it to test2.py. \\ \hline
+  \strong{put test1.py test2.py}  & Copy the local file test1.py to the \hpc and rename it to test2.py. \\ \hline
   \strong{bye}                     & Quit the sftp session \\ \hline
   \strong{mget *.cc}               & Copy all the remote files with extension ``.cc'' to the local directory.  \\ \hline
   \strong{mput *.h}                & Copy all he local files with extension ``.h'' to the \hpc. \\ \hline
@@ -292,9 +293,11 @@ window and jump in!
 
   \url{https://filezilla-project.org/download.php}
 
-  Tip: Some users might get the notification that Filezilla.app cannot be opened
+  \begin{tip}
+  Some users might get the notification that Filezilla.app cannot be opened
   because it is from an unidentified developer. Check out the Mac Gatekeeper at
   \url{http://support.apple.com/kb/HT5290}
+  \end{tip}
 
   Start FileZilla and login to the \hpc with the following details:
 
@@ -325,14 +328,14 @@ Linux on the \hpc is Bash (Bourne Again Shell) and can be used for the
 following purposes:
 
 \begin{enumerate}
-\item  Configure look and feel of shell.
+\item  Configure look and feel of the shell.
 \item  Setup terminal settings depending on which terminal you're using.
-\item  Set the search path for running executable's.
+\item  Set the search path for running executables.
 \item  Set environment variables as needed by programs.
-\item  Set convenient abbreviations for heavily used values
+\item  Set convenient abbreviations for heavily used values.
 \item  Run commands that you want to run whenever you log in or log out.
 \item  Setup aliases and/or shell function to automate tasks to save typing and time.
-\item  Changing bash prompt.
+\item  Changing the bash prompt.
 \item  Setting shell options.
 \end{enumerate}
 
@@ -352,7 +355,7 @@ In order to administer the active software and their environment variables, a
 \item  Activates or de-activates \underbar{software packages} and their dependencies.
 \item  Allows setting and unsetting of \underbar{environment variables}, including adding and deleting entries from database-type environment variables.
 \item  Does this in a \underbar{shell-independent} fashion (necessary information is stored in the accompanying module configuration file).
-\item  Takes care of \underbar{versioning aspects:} For many libraries, multiple versions are installed and maintained. The module system also takes care of the versioning of software packages in case multiple versions are installed. For instance, it?does not allow multiple versions to be loaded at same time.
+\item  Takes care of \underbar{versioning aspects:} For many libraries, multiple versions are installed and maintained. The module system also takes care of the versioning of software packages in case multiple versions are installed. For instance, it does not allow multiple versions to be loaded at same time.
 \item  Takes care of \underbar{dependencies:} Another issue arises when one considers library versions and the dependencies they create. Some software requires an older version of a particular library to run correctly (or at all). Hence a variety of version numbers is available for important libraries.
 \end{enumerate}
 
@@ -390,10 +393,10 @@ This will load the most recent version of MATLAB.
 
 For some packages, e.g., OpenMPI, multiple versions are installed; the load
 command will automatically choose the most recent version (i.e., the
-lexicographically last after the "/") or the default version (as set by the
+lexicographically last after the ``/'') or the default version (as set by the
 system administrators). However, the user can (and probably should, to avoid
 surprises when never versions are installed) specify a particular version,
-e.g.:
+e.g.,
 
 \begin{prompt}
 %\shellcmd{module load Python/2.7.3-ictce-4.0.1}%
@@ -414,7 +417,7 @@ Currently Loaded Modulefiles:
 
 It is important to note at this point that other modules (e.g., ictce/4.0.1)
 are also listed, although the user did not explicitly load them. This is
-because ``Python/2.7.3-ictce-4.0.1'' depends on it (as indicated in it's name),
+because ``Python/2.7.3-ictce-4.0.1'' depends on it (as indicated in its name),
 and the system administrator specified that the ``ictce/4.0.1'' module should
 be loaded whenever the Python module is loaded. There are advantages and
 disadvantages to this, so be aware of automatically loaded modules whenever
@@ -424,8 +427,8 @@ To unload a module, one can use the ``module unload'' command. It works
 consistently with the load command, and reverses the latter's effect. However,
 the dependencies of the package are NOT automatically unloaded; the user shall
 unload the packages one by one. One can however unload automatically loaded
-modules manually, to debug some problem. When the 'Python' module is unloaded,
-only the following module remains:
+modules manually, to debug some problem. When the ``Python'' module is unloaded,
+only the following modules remain:
 
 \begin{prompt}
 %\shellcmd{module unload Python}%
@@ -438,7 +441,7 @@ Currently Loaded Modulefiles:
 
 Notice that the version was not specified: the module system is sufficiently
 clever to figure out what the user intends. However, checking the list of
-currently loaded modules is always a good idea, just to make sure\ldots
+currently loaded modules is always a good idea, just to make sure \ldots
 
 In order to unload all modules at once, and hence be sure to start in a clean
 state, you can use:
@@ -452,7 +455,7 @@ modules specifically needed by applications in that job description. This
 ensures that no version conflicts occur if the user loads module using his
 '.bashrc' file.
 
-Finally, modules need not be loaded one by one; the two 'load' commands can be
+Finally, modules need not be loaded one by one; the two ``load'' commands can be
 combined as follows:
 
 \begin{prompt}
@@ -499,7 +502,7 @@ scripts/2.3.6
 scripts/2.5.1
 scripts/2.6.0
 %\shellcmd{module load scripts/1.2.0}%
-%\shellcmd{module load scripts /2.6.0 }%
+%\shellcmd{module load scripts /2.6.0}%
 scripts/2.6.0(13):ERROR:150: Module 'scripts/2.6.0' conflicts with the currently loaded module(s) 'scripts/1.2.0'
 scripts/2.6.0(13):ERROR:102: Tcl command execution failed: conflict scripts
 %\shellcmd{module switch scripts/2.6.0}%

--- a/intro-HPC/ch_program_examples.tex
+++ b/intro-HPC/ch_program_examples.tex
@@ -1,4 +1,5 @@
 \chapter{Program examples}
+\label{ch:program-examples}
 
 Go to our examples:
 \begin{prompt}

--- a/intro-HPC/ch_quick_reference_guide.tex
+++ b/intro-HPC/ch_quick_reference_guide.tex
@@ -1,4 +1,5 @@
 \chapter{\hpc Quick Reference Guide}
+\label{ch:quick-reference-guide}
 
 \begin{tabular}{|l|l|} \hline
 \multicolumn{2}{|c|}{\strong{Login}} \\ \hline
@@ -29,14 +30,14 @@ Show compute node       & qstat -n $<$jobid$>$ \\ \hline
 Delete job              & qdel $<$jobid$>$ \\ \hline
 Status of all your jobs & qstat \\ \hline
 Show all jobs on  queue & showq \\ \hline
-Show queue summary      & qstat -q \\ \hline
-Show some queue         & qstat -f -Q $<$queue$>$ \\ \hline
+%Show queue summary      & qstat -q \\ \hline
+%Show some queue         & qstat -f -Q $<$queue$>$ \\ \hline
 Submit Interactive job  & qsub -I \\ \hline
 \end{tabular}
 
 \begin{tabular}{|l|l|} \hline
 \multicolumn{2}{|c|}{\strong{Disk quota}} \\ \hline
-Check your disk quota & nmlsquota \\ \hline
+Check your disk quota & mmlsquota \\ \hline
 Check disk quota nice & show\_quota.py \\ \hline
 Local disk usage      & du -h . \\ \hline
 Overall disk usage    & df -a \\ \hline

--- a/intro-HPC/ch_running_batch_jobs.tex
+++ b/intro-HPC/ch_running_batch_jobs.tex
@@ -1,4 +1,5 @@
 \chapter{Running batch jobs}
+\label{ch:running-batch-jobs}
 
 In order to have access to the compute nodes of a cluster, one has to make use
 of the job system. The system software that handles your batch jobs consists of
@@ -16,7 +17,7 @@ nodes} of the cluster. There you can prepare the work you want to get done on
 the cluster by, e.g., installing or compiling programs, setting up data sets,
 etc. The computations however, should not be performed on this login node. The
 actual work is done on the cluster's \strong{compute nodes}. These compute
-nodes are managed by the job scheduling software (MOAB) and a Resource Manager
+nodes are managed by the job scheduling software (Moab) and a Resource Manager
 (TORQUE), which decides when and on which compute nodes the jobs can run. It is
 usually not necessary (and in some cases not permitted) to log on to the
 compute nodes directly. A user can (and should) monitor his or her jobs
@@ -37,11 +38,11 @@ execution. All the necessary input or required options have to be specified on
 the command line, or needs to be put in input or configuration files.
 
 As an example, we will run a MATLAB script, which you will find in the examples
-subdirectory on the \hpc When you received an account to the \hpc a
+subdirectory on the \hpc. When you received an account to the \hpc a
 subdirectory with examples was automatically generated for you.
 
 Remember that you have copied the contents of the HPC examples directory to
-your home directory, so that you have your \strong{own personal }copy (editable
+your home directory, so that you have your \strong{own personal} copy (editable
 and over-writable) and that you can start using the examples. If you haven't
 done so:
 
@@ -63,15 +64,15 @@ Each time you want to execute a program on the \hpc you'll need 2 things:
   \item[A configuration script] (also called a job-script), which will define the computer resource requirements of the program, the required additional software packages and which will start the actual executable.  The \hpc needs to know:
     \begin{enumerate}
       \item  the type of compute nodes;
-      \item  the number of CPU's;
+      \item  the number of CPUs;
       \item  the amount of memory;
       \item  the expected duration of the execution time;
-      \item  the name of the files which will contain the output (i.e. stdout) and error (i.e. stderr) messages;
+      \item  the name of the files which will contain the output (i.e., stdout) and error (i.e., stderr) messages;
       \item  what executable to start, and its arguments.
     \end{enumerate}
 \end{description}
 
-Later on, the \hpc shall have to define (or to adapt) their own
+Later on, the \hpc user shall have to define (or to adapt) his/her own
 configuration scripts. For now, all required configuration scripts for the
 exercises are provided for you in the examples subdirectories.
 
@@ -84,11 +85,11 @@ total 512
 -rw-r--r-- 1 %\userid% 609 Sep 11 10:25 fibo.pl
 \end{prompt}
 
-In this directory you find a PERL script (named `fibo.pl') and a PBS
-configuration script (named `fibo.pbs').
+In this directory you find a Perl script (named ``fibo.pl'') and a job-script
+(named ``fibo.pbs'').
 
 \begin{enumerate}
-\item  The PERL script calculates the first 30 Fibonacci numbers.
+\item  The Perl script calculates the first 30 Fibonacci numbers.
 \item  The job-script is actually a standard Unix/Linux shell script that
   contains a few extra comments at the beginning that specify directives to
   PBS.  These comments all begin with \strong{\#PBS}.
@@ -132,12 +133,12 @@ On the command line, you would run this using:
 [29] -> 514229
 \end{prompt}
 
-\underbar{Remark}: Recall that you have now executed the PERL script locally on
+\underbar{Remark}: Recall that you have now executed the Perl script locally on
 one of the login-nodes of the \hpc cluster.  Of course, this is not our final
 intention; we want to run the script on any of the compute nodes. Also, it is
 not considered as good practice, if you ``abuse'' the login-nodes for testing
-your scripts and executable's. It will be explained later on how you can
-reserve your own compute-node by (by opening an interactive session) to test
+your scripts and executables. It will be explained later on how you can
+reserve your own compute-node (by opening an interactive session) to test
 your software. But for the sake of acquiring a good understanding of what is
 happening, you are pardoned for this example.
 
@@ -146,7 +147,7 @@ need to be executed on the compute node:
 
 \examplecode{bash}{fibo.pbs}
 
-So, jobs are submitted as scripts (bash, perl, python, etc.), which specify the
+So, jobs are submitted as scripts (bash, Perl, Python, etc.), which specify the
 parameters related to the jobs such as expected runtime (walltime), mail
 notification, etc. These parameters can also be specified on the command line.
 
@@ -159,10 +160,10 @@ execution, using the qsub (Queue SUBmit) command:
 \end{prompt}
 
 The qsub command returns a job identifier on the HPC cluster. The important
-part is the number (e.g. '\jobnumber'); this is a unique identifier for the job
+part is the number (e.g., ``\jobnumber''); this is a unique identifier for the job
 and can be used to monitor and manage your job.
 
-Go and drink some coffee \dots but not too long.
+Go and drink some coffee \dots\ but not too long.
 
 When you return, check the contents of the directory:
 
@@ -184,12 +185,12 @@ Explore the contents of the 2 new files:
 
 These files are used to store the standard output and error that would
 otherwise be shown in the terminal window. By default, they have the same name
-as that of the PBS script, i.e. 'fibo.pbs' as base name, followed by the
-extension '.o' (output) and '.e' (error), respectively, and the job number
+as that of the PBS script, i.e., ``fibo.pbs'' as base name, followed by the
+extension ``.o'' (output) and ``.e'' (error), respectively, and the job number
 ('\jobnumber' for this example). The error file will be empty, at least if all went
 well. If not, it may contain valuable information to determine and remedy the
 problem that prevented a successful run. The standard output file will contain
-the results of your calculation (here, the output of the matlab script)
+the results of your calculation (here, the output of the MATLAB script)
 
 \section{Monitoring and managing your job(s)}
 
@@ -235,7 +236,7 @@ finished using (uid is your VSC user name on the system):
 
 % Manually indented, please keep this as is
 \begin{prompt}
-%\shellcmd{qstat -u $<$uid$>$}%
+%\shellcmd{qstat}%
 %\pbsserver%:
 Job ID      Name    User      Time Use S Queue
 ----------- ------- --------- -------- - -----
@@ -244,7 +245,7 @@ Job ID      Name    User      Time Use S Queue
 
 Here:
 \begin{description}
-  \item[Job id] the job's unique identifier
+  \item[Job ID] the job's unique identifier
   \item[Name] the name of the job
   \item[User] the user that owns the job
   \item[Time Use] the elapsed walltime for the job
@@ -265,9 +266,9 @@ The state S can be any of  the following:
 
 \section{Examining the queue}
 
-As we learned above, MOAB is the software application that actually decides
+As we learned above, Moab is the software application that actually decides
 when to run your job and what resources your job will run on. You can look at
-the queue by using either the PBS \strong{qstat} command or the MOAB
+the queue by using either the PBS \strong{qstat} command or the Moab
 \strong{showq} command. By default, \strong{qstat} will display the queue
 ordered by \strong{JobID}, whereas \strong{showq} will display jobs grouped by
 their state (``running'', ``idle'', or ``hold'') then ordered by priority.
@@ -322,7 +323,7 @@ Total jobs:  540
 There are 3 categories, the \strong{active}, \strong{eligible} and \strong{blocked} jobs.
 
 \begin{description}
-  \item[Active jobs] are jobs that are running or starting and that consume computer resources. The amount of time remaining (w.r.t. walltime, sorted to earliest completion time) and the start time are displayed. This will give you an idea about the foreseen completion time. These jobs could be in a number of states:
+  \item[Active jobs] are jobs that are running or starting and that consume computer resources. The amount of time remaining (w.r.t.\ walltime, sorted to earliest completion time) and the start time are displayed. This will give you an idea about the foreseen completion time. These jobs could be in a number of states:
 
   \begin{description}
     \item[Started] attempting to start, performing pre-start tasks
@@ -363,7 +364,7 @@ it is necessary to ensure your jobs will run properly.
 \subsection{Generic resource requirements}
 
 The \strong{qsub} command takes several options to specify the requirements, of which we
-list the most commonly used once below.
+list the most commonly used once below. \\
 
 \begin{prompt}
 %\shellcmd{qsub -l walltime=2:30:00}%
@@ -372,21 +373,21 @@ list the most commonly used once below.
 For the simplest cases, only the amount of maximum estimated execution time
 (called ``walltime'' is really important. Here, the job will not require more
 than 2 hours, 30 minutes to complete. As soon as the job would take more time,
-it will be `killed' (terminated) by the job scheduler.  As such, it does not
-harm if you \emph{slightly} overestimate the maximum execution time.
+it will be ``killed'' (terminated) by the job scheduler.  As such, it does not
+harm if you \emph{slightly} overestimate the maximum execution time. \\
 
 \begin{prompt}
 %\shellcmd{qsub -l mem=4gb}%
 \end{prompt}
 
-The job requires no more than 4 Gb of memory.
+The job requires no more than 4 GB of memory. \\
 
 \begin{prompt}
 %\shellcmd{qsub -l nodes=5:ppn=2}%
 \end{prompt}
 
 The job requires 5 compute nodes with two cores on each node (ppn stands for
-"processors per node", where processor is used to refer to indivual cores)
+``processors per node'', where processor is used to refer to indivual cores). \\
 
 \begin{prompt}
 %\shellcmd{qsub -l nodes=1:westmere}%
@@ -401,7 +402,7 @@ These options can either be specified on the command line, e.g.
 %\shellcmd{qsub -l nodes=1:harpertown,mem=2gb fibo.pbs}%
 \end{prompt}
 
-or in the job-script itself using the \#PBS-directive, so 'fibo.pbs' could be modified to:
+or in the job-script itself using the \#PBS-directive, so ``fibo.pbs'' could be modified to:
 
 \begin{code}{bash}
 #!/bin/bash -l
@@ -414,7 +415,7 @@ cd $PBS_O_WORKDIR
 Note that the resources requested on the command line will override those
 specified in the PBS file.
 
-\subsection{Available job categories (Torque queues)}
+\subsection{Available job categories (TORQUE queues)}
 
 In order to guarantee a fair share access to the computer resources to all
 users, only a limited number of jobs with certain walltimes are possible per
@@ -425,7 +426,7 @@ queues), depending on the their walltime specification.  A user is allowed to
 run up to a certain maximum number of jobs in each of these walltime
 categories.
 
-The currently defined queue categories (with walltime limits) for the \hpc
+The currently defined walltime categories for the \hpc
 are:
 
 \inputsite{queue-table}
@@ -437,13 +438,14 @@ be changed over time.
 \ifantwerpen
 % TODO : already adapt this text according to the new common user experience rules, and make it general....
 When a user submits a job with a walltime of 15 days, the queue manager will
-put the job in the qxxlong category.  The user can submit up to 8 jobs with
+put the job in the walltime category 7 days--21 days.  The user can submit up to 8 jobs with
 this high walltimes (queable = 8), but only 2 of those jobs will be eligible
 for execution (runnable=2) at the same time.  A detailed description of the
-fair-share mechanisms will follow in Chapter 9. For longer running jobs,
-\emph{checkpointing} (See Chapter 13) is necessary.
+fair-share mechanisms will follow in \autoref{ch:hpc-policies}. For longer running jobs,
+\emph{checkpointing} (See \autoref{ch:checkpointing}) is necessary.
 \fi
 
+\iffalse
 Apart from specifying the \emph{walltime}, you can also explicitly define the
 queue you're submitting your job to.
 
@@ -500,6 +502,7 @@ used:
 
 This will list additional restrictions such as the maximum walltime of the jobs
 and the maximum number of jobs that a user can have in that queue.
+\fi
 
 \subsection{Node-specific properties}
 
@@ -511,8 +514,8 @@ that these properties may very over the different VSC sites.
 \strong{Property} & \strong{Explanation}                                        \\ \hline
 harpertown        & only use Intel processors from the Harpertown family (54xx) \\ \hline
 westmere          & only use Intel processors from the Westmere family (56xx)   \\ \hline
-sandybridge       & only use Intel processors from the Sandy Bridge family      \\ \hline
-ivybridge         & only use Intel processors from the Ivy Bridge family        \\ \hline
+sandybridge       & only use Intel processors from the Sandy Bridge family (26xx)      \\ \hline
+ivybridge         & only use Intel processors from the Ivy Bridge family (26xx-v2)       \\ \hline
 ib                & use Infiniband interconnect                                 \\ \hline
 \end{tabular}
 
@@ -528,7 +531,7 @@ rack number, etc.
 
 At some point your job finishes, so you may no longer see the job ID in the
 list of jobs when you run \emph{qstat} (since it will only be listed for a few
-minutes after completion with state "C"). After your job finishes, you should
+minutes after completion with state ``C''). After your job finishes, you should
 see the standard output and error of your job in two files, located by default
 in the directory where you issued the \emph{qsub} command.
 
@@ -536,7 +539,7 @@ in the directory where you issued the \emph{qsub} command.
 When you navigate to that directory and list its contents, you should see them:
 
 \begin{prompt}
-%\emph{ls -l}%
+%\shellcmd{ls -l}%
 total 1024
 -rw-r--r-- 1 %\userid%  609 Sep 11 10:54 fibo.pl
 -rw-r--r-- 1 %\userid%   68 Sep 11 10:53 fibo.pbs
@@ -566,7 +569,7 @@ connected to your $<$vsc-account$>$. This is the e-mail address that is linked
 to the university account, which was used during the registration process.
 
 You can force a job to fail by specifying an unrealistic wall-time for the
-previous example.  Lets give the `\emph{fibo.pbs}' job just one second to
+previous example.  Lets give the ``\emph{fibo.pbs}'' job just one second to
 complete:
 
 \begin{prompt}
@@ -589,7 +592,7 @@ See Administrator for help
 
 You can instruct the \hpc to send an e-mail to your e-mail address whenever a
 job \strong{b}egins, \strong{e}nds and/or \strong{a}borts, by adding the
-following lines to the job-script 'fibo.pbs':
+following lines to the job-script ``fibo.pbs'':
 
 \begin{code}{bash}
 #PBS -m b
@@ -607,7 +610,7 @@ These options can also be specified on the command line.  Try it and see what
 happens:
 
 \begin{prompt}
-%\shellcmd{qsub -mabe -M $<$your e-mail address$>$ fibo.pbs}%
+%\shellcmd{qsub -m abe -M $<$your e-mail address$>$ fibo.pbs}%
 \end{prompt}
 
 You don't have to specify the e-mail address. In such cases, the system will

--- a/intro-HPC/ch_running_interactive_jobs.tex
+++ b/intro-HPC/ch_running_interactive_jobs.tex
@@ -1,4 +1,5 @@
 \chapter{Running interactive jobs}
+\label{ch:running-interactive-jobs}
 
 \section{Introduction}
 
@@ -18,8 +19,10 @@ The syntax for \emph{qsub} for submitting an interactive PBS job is:
 
 \section{Interactive jobs, without X support}
 
-\emph{\underbar{Tip}: Find the code in
-``\tilde/\exampledir''}
+\begin{tip}
+Find the code in
+``\tilde/\exampledir''
+\end{tip}
 
 First of all, in order to know on which computer you're working, enter:
 \begin{prompt}
@@ -64,12 +67,12 @@ This computer name looks strange, but bears some logic in it.  It provides the
 system administrators with information where to find the computer in the
 computer room.
 
-The computer ``r1e3cn18'' stands for:
+The computer ``\emph{\computenodeshort}'' stands for:
 
 \begin{enumerate}
-\item  ``r1'' is rack \#1.
-\item  ``e3'' is enclosure \#3.
-\item  ``cn18'' is compute node \#18.
+\item  ``r5'' is rack \#5.
+\item  ``c3'' is enclosure/chassis \#3.
+\item  ``cn13'' is compute node \#13.
 \end{enumerate}
 
 With this naming convention, the system administrator can easily find the
@@ -113,9 +116,9 @@ You can exit the Interactive session with:
 
 Note that you can now use this allocated node for 1 hour.  After this hour you
 will be automatically disconnected. You can change this ``usage time'' by
-explicitly specifying a ``walltime'' , i.e. the time that you want to work on
+explicitly specifying a ``walltime'', i.e., the time that you want to work on
 this node.  (Think of walltime as the time elapsed when watching the clock on
-the wall.
+the wall.)
 
 You can work for 3 hours by:
 \begin{prompt}
@@ -161,7 +164,7 @@ and rich input device capability for networked computers.
 \fi
 
 \ifwindows
-  \paragraph{ Install XMing}
+  \paragraph{Install XMing}
 
   The first task is to install the Xming software.
 
@@ -173,43 +176,39 @@ and rich input device capability for networked computers.
     \item  Run the Xming setup program on your Windows desktop.
     \item  Keep the proposed default folders for the Xming installation.
     \item  When selecting the components that need to be installed, make sure to
-      select `\emph{XLaunch wizard}' and `\emph{Normal PuTTY Link SSH client}'.
-  \end{enumerate}
+      select ``\emph{XLaunch wizard}'' and ``\emph{Normal PuTTY Link SSH client}''.
 
   \includegraphics*[width=4.27in, height=3.32in, keepaspectratio=false]{img0500}
 
-  \begin{enumerate}
   \item  We suggest to create a Desktop icon for Xming and XLaunch.
-  \item  And $<$\textit{Install}$>$.
+  \item  And \keys{Install}.
   \end{enumerate}
 
   And now we can run Xming:
 
   \begin{enumerate}
-  \item  \includegraphics*[width=0.32in, height=0.32in, keepaspectratio=false]{img0501}  Select XLaunch from the Start Menu or by double-clicking the Desktop icon.
-  \item  Select $<$\textit{Multiple Windows}$>$. This will open each application in a separate window.
-  \end{enumerate}
+  \item Select XLaunch from the Start Menu or by double-clicking the Desktop icon.
+
+  \item  Select \keys{Multiple Windows}. This will open each application in a separate window.
+
+  \includegraphics*[width=3.11in, height=3.11in, keepaspectratio=false]{img0501}  
+
+
+  \item  Select \keys{Start no client} to make XLaunch wait for other programs (such as PuTTY).
 
   \includegraphics*[width=4.60in, height=3.57in, keepaspectratio=false]{img0502}
 
-  \begin{enumerate}
-  \item  Select $<$\textit{Start no client}$>$ to make XLaunch wait for other programs (such as PuTTY).\includegraphics*[width=4.01in, height=3.11in, keepaspectratio=false]{img0503}
-  \end{enumerate}
 
-  \begin{enumerate}
-  \item  Select $<$\textit{Clipboard}$>$ to share the clipboard.
-  \end{enumerate}
+  \item  Select \keys{Clipboard} to share the clipboard.
 
-  \includegraphics*[width=3.90in, height=3.03in, keepaspectratio=false]{img0503}
+  \includegraphics*[width=4.01in, height=3.11in, keepaspectratio=false]{img0503}
 
-  \begin{enumerate}
-  \item  Finally $<$\textit{Save configuration}$>$ into a file. You can keep the default filename and save it in your Xming installation directory.
-  \end{enumerate}
+
+  \item  Finally \keys{Save configuration} into a file. You can keep the default filename and save it in your Xming installation directory.
 
   \includegraphics*[width=3.90in, height=3.03in, keepaspectratio=false]{img0504}
 
-  \begin{enumerate}
-  \item  Now Xming is running in the background \ldots and you can launch a graphical application in your PuTTY terminal.
+  \item  Now Xming is running in the background \ldots\\ and you can launch a graphical application in your PuTTY terminal.
   \item  Open a PuTTY terminal and connect  to the HPC.
   \item  In order to test the X-server, run ``\emph{xclock}''. ``\emph{xclock}'' is the standard GUI clock for the X Window System.
   \end{enumerate}
@@ -223,6 +222,20 @@ and rich input device capability for networked computers.
   displayed on your Windows machine.
 
   \includegraphics*[width=1.44in, height=1.62in, keepaspectratio=false]{img0505}
+
+  You can close your clock and connect further to a compute node with again your
+  X-forwarding enabled:
+
+  \begin{prompt}
+  %\shellcmd{qsub -I -X}%
+  qsub: waiting for job %\jobid% to start
+  qsub: job %\jobid% ready
+  %\shellcmd{hostname -f}%
+  %\computenode%
+  %\shellcmd{xclock}%
+  \end{prompt}
+
+  and you should see your clock again.
 
   \paragraph{SSH Tunnel}
 
@@ -260,10 +273,10 @@ and rich input device capability for networked computers.
     \item  Log in on the login node via PuTTY.
     \item  Start the server job, note the compute node's name the job is running
     on (e.g., \computenode), as well as the port the server is listening on
-  (e.g., '54321').  \item  Set up the tunnel:
+  (e.g., ``54321'').  \item  Set up the tunnel:
 
     \begin{enumerate}
-      \item  In the ``\emph{Category}'' pane, expand $<$\emph{Connection}$>$$<$\emph{SSH}$>$, and select $<$\emph{Tunnels}$>$ as show below:
+      \item  In the ``\emph{Category}'' pane, expand \menu[,]{Connection,SSH}, and select \keys{Tunnels} as show below:
     \end{enumerate}
   \end{enumerate}
 
@@ -272,13 +285,14 @@ and rich input device capability for networked computers.
   \begin{enumerate}
     \item  In the ``\emph{Source port}'' field, enter the local port to use (e.g., \emph{12345}).
     \item  In the ``\emph{Destination}'' field, enter \emph{$<$hostname$>$:$<$server-port$>$} (e.g., \computenode:54321 as in the example above).
-    \item  Click the $<$\emph{Add}$>$ button.
-    \item  Click the $<$\emph{Open}$>$ button
+    \item  Click the \keys{Add} button.
+    \item  Click the \keys{Open} button
   \end{enumerate}
 
   The tunnel is now ready to use.
 \fi % ENDIF WINDOWS
 
+\ifmacORlinux
 \subsection{Connect with X-forwarding}
 
 In order to get the graphical output of your application (which is running on a
@@ -297,7 +311,7 @@ First exit and re-connect to the \hpc with X-forwarding enabled:
 %\loginhost%
 \end{prompt}
 
-We first check whether our GUI's on the login node are decently forwarded to
+We first check whether our GUIs on the login node are decently forwarded to
 your screen on your local machine. An easy way to test it is by running a small
 X-application on the login node. Type:
 
@@ -322,6 +336,7 @@ qsub: job %\jobid% ready
 \end{prompt}
 
 and you should see your clock again.
+\fi
 
 \subsection{Run simple example}
 
@@ -331,7 +346,7 @@ to click a button.
 
 Now run the message program:
 \begin{prompt}
-%\shellcmd{./message}%
+%\shellcmd{./message.py}%
 \end{prompt}
 
 You should see the following message appearing.
@@ -356,9 +371,9 @@ Click any button and see what happens.
 
 In this last example, we will show you that you can just work on this compute
 node, just as if you were working locally on your desktop.  We will run the
-Fibonacci example of the previous Chapter again, but now in full Interactive
+Fibonacci example of the previous chapter again, but now in full interactive
 mode. Remember that it was written in MATLAB, so we first load the MATLAB
-modules.
+module.
 
 \begin{prompt}
 %\shellcmd{module load MATLAB}%

--- a/intro-HPC/ch_running_jobs_with_input.tex
+++ b/intro-HPC/ch_running_jobs_with_input.tex
@@ -1,4 +1,5 @@
 \chapter{Running jobs with input/output data}
+\label{ch:running-jobs-with-input-output-data}
 
 You have now learned how to start a batch job and how to start an interactive
 session.  The next question is how to deal with input and output files, where
@@ -30,7 +31,7 @@ total 2304
 \end{prompt}
 
 Now, let us inspect the contents of the first executable (which is just a
-python script with execute permission).
+Python script with execute permission).
 
 \examplecode{Python}{file1.py}
 
@@ -54,7 +55,7 @@ Submit it:
 \end{prompt}
 
 After the job has finished, inspect the local directory again, i.e., the
-directory where you executed the \emph{qsub} commando:
+directory where you executed the \emph{qsub} command:
 
 \begin{prompt}
 %\shellcmd{ls -l}%
@@ -79,7 +80,7 @@ Some observations:
 \item The file ``file1a.pbs.e\jobnumber'' contains all the text that was written to the standard error stream (``stderr'').
 \end{enumerate}
 
-Inspect their contents\dots and remove the files
+Inspect their contents \dots\ and remove the files
 
 \begin{prompt}
 %\shellcmd{cat Hello.txt}%
@@ -88,8 +89,10 @@ Inspect their contents\dots and remove the files
 %\shellcmd{rm Hello.txt file1a.pbs.o\jobnumber file1a.pbs.e\jobnumber}%
 \end{prompt}
 
-\strong{Tip}: Type ``cat H'' and press the \strong{TAB} button, and it will
+\begin{tip}
+Type ``cat H'' and press the \keys{TAB} button, and it will
 \strong{expand} into full filename.
+\end{tip}
 
 \subsection{Filenames using the name of the job}
 
@@ -101,7 +104,7 @@ Check the contents of the job script and execute it.
 %\shellcmd{qsub file1b.pbs}%
 \end{prompt}
 
-Inspect the contents again \dots and remove the generated files:
+Inspect the contents again \dots\ and remove the generated files:
 
 \begin{prompt}
 %\shellcmd{ls}%
@@ -145,8 +148,8 @@ The following locations are available:
 \begin{tabular}{|p{0.35\textwidth}|p{0.65\textwidth}|} \hline
 \strong{Variable} & \strong{Description} \\ \hline
 \$VSC\_HOME            & The data stored here should be relatively small (e.g., no files or directories larger than a gigabyte), and not generating very intense I/O during jobs. Various kinds of \strong{configuration files} are also stored here, such as the ssh-keys, .bashrc, or MATLAB and Eclipse configuration files, etc. \newline The default directory is /user/\sitename/xxx/$<$vsc-account$>$. \\ \hline
-\$VSC\_DATA            & A bigger 'workspace', for \strong{datasets}, results, logfiles, etc. This file-system can be used for higher I/O loads, but for I/O bound jobs, you might be better of using (one of) the 'scratch' file-system(s). Also, if you are developing your own software, builds of large projects should be conducted here. The default directory is /data/\sitename/xxx/$<$vsc-account$>$. \\ \hline
-\$VSC\_SCRATCH \$VSC\_SCRATCH\_SITE \$VSC\_SCRATCH\_GLOBAL & For \strong{temporary} or transient data; there is typically no backup for these file-systems, and 'old' data may be removed automatically. The default directory is /scratch/\sitename/xxx/$<$vsc-account$>$ \\   \hline
+\$VSC\_DATA            & A bigger ``workspace'', for \strong{datasets}, results, logfiles, etc. This file-system can be used for higher I/O loads, but for I/O bound jobs, you might be better of using (one of) the ``scratch'' file-system(s). Also, if you are developing your own software, builds of large projects should be conducted here. The default directory is /data/\sitename/xxx/$<$vsc-account$>$. \\ \hline
+\$VSC\_SCRATCH \$VSC\_SCRATCH\_SITE \$VSC\_SCRATCH\_GLOBAL & For \strong{temporary} or transient data; there is typically no backup for these file-systems, and ``old'' data may be removed automatically. The default directory is /scratch/\sitename/xxx/$<$vsc-account$>$ \\   \hline
 \$VSC\_SCRATCH\_NODE & For \strong{temporary} or transient data on the local compute node, where fast access is important; there is no backup for these file-systems. The user is responsible for cleaning up the data after use.\newline This space that is available per node. The default directory is /tmp. \\ \hline
 \ifgent
 \$VSC\_SCRATCH\_CLUSTER & \\ \hline
@@ -217,7 +220,7 @@ The rules are:
 \subsection{Your home directory (\$VSC\_HOME)}
 
 You home directory is where you arrive by default when you login to the
-cluster. Your shell refers to it as "\tilde" (tilde), and it absolute path is also
+cluster. Your shell refers to it as ``\tilde'' (tilde), and it absolute path is also
 stored in the environment variable \$VSC\_HOME.
 
 The data stored here should be relatively small (e.g., no files or directories
@@ -232,7 +235,7 @@ account. Examples are:
 \textbf{File or Directory} & \textbf{Description} \\ \hline
 .ssh/                      & This directory contains some files necessary for you to login to the cluster and to submit jobs on the cluster. Do not remove them, and do not alter anything if you don't know what you're doing! \\ \hline
 .bash\_profile             & When you login (type username and password) remotely via ssh, .bash\_profile is executed to configure your shell before the initial command prompt. \\ \hline
-.bashrc                    & This script is executed every time you start a session on the cluster: when you login to the cluster and when a job starts. You could edit this file and, e.g., add "module load XYZ" if you want to automatically load module XYZ whenever you login to the cluster, although we do not recommend to load modules in your .bashrc. \\ \hline
+.bashrc                    & This script is executed every time you start a session on the cluster: when you login to the cluster and when a job starts. You could edit this file and, e.g., add ``module load XYZ'' if you want to automatically load module XYZ whenever you login to the cluster, although we do not recommend to load modules in your .bashrc. \\ \hline
 .bash\_history             & This file contains the commands you typed at your shell prompt, in case you need them again. \\ \hline
 \end{tabular}
 
@@ -250,7 +253,7 @@ speed you'll achieve on this volume.
 \subsection{Your scratch space (\$VSC\_SCRATCH)}
 
 To enable quick writing from your job, a few extra file systems are available
-on the work nodes. These extra file systems are called scratch folders, and can
+on the compute nodes. These extra file systems are called scratch folders, and can
 be used for storage of temporary and/or transient data (temporary results,
 anything you just need during your job, or your batch of jobs).
 
@@ -281,19 +284,16 @@ Each type of scratch has its own use:
 \end{enumerate}
 
 \textbf{Global scratch (\$VSC\_SCRATCH\_GLOBAL)}
-\begin{enumerate}
-  \item In the long term, this scratch space will be available throughout the
-    whole VSC. At the time of writing, the global scratch is just the same
-    volume as the site scratch, and thus contains the same data.
-\end{enumerate}
+At the time of writing, the global scratch is just the same
+volume as the site scratch, and thus contains the same data.
 
 \subsection{Local data}
 
 One could also opt to use some local disk-space on the compute node itself.
 
 The \strong{advantage} is that this local disk will perform the best for
-disk-IO intensive applications.  The \strong{drawback} is that those disks are
-limited in size (e.g., approx. 100Gb depending on the node) and that these
+disk-I/O intensive applications.  The \strong{drawback} is that those disks are
+limited in size (e.g., approx.\ 100 GB depending on the node) and that these
 disks are not visible from outside.
 
 But it is for sure useful when you are working with temporary output data in a
@@ -309,19 +309,21 @@ You'll best use the ``/tmp'' directory, which can be accessed via the
 
 \section{Writing Output files}
 
-\textit{\underbar{Tip}: Find the code of the exercises in ``\tilde/\exampledir''}
+\begin{tip}
+Find the code of the exercises in ``\tilde/\exampledir''
+\end{tip}
 
 In the next exercise, you will generate a file in the \$VSC\_SCRATCH directory.
-In order to generate some CPU- and disk-IO load, we will
+In order to generate some CPU- and disk-I/O load, we will
 
 \begin{enumerate}
-\item  take a random integer between 1 and 2000 and calculate all primes up to that limit; and
-\item  repeat this action 30.000 times; and
-\item  write the output to the "primes\_1.txt" output file in the SCRATCH-directory.
+\item  take a random integer between 1 and 2000 and calculate all primes up to that limit;
+\item  repeat this action 30.000 times;
+\item  write the output to the ``primes\_1.txt'' output file in the \$VSC\_SCRATCH-directory.
 \end{enumerate}
 
 Check the Python and the PBS file, and submit the job: Remember that this is
-already a more serious (disk-IO and computational intensive) job, which takes
+already a more serious (disk-I/O and computational intensive) job, which takes
 approximately 3 minutes on the \hpc.
 
 \begin{prompt}
@@ -336,17 +338,19 @@ approximately 3 minutes on the \hpc.
 
 \section{Reading Input files}
 
-\textit{\underbar{Tip}: Find the code of the exercise ``file3.py'' in
-``\tilde/\exampledir''}.
+\begin{tip}
+Find the code of the exercise ``file3.py'' in
+``\tilde/\exampledir''.
+\end{tip}
 
 In this exercise, you will
 \begin{enumerate}
-\item  Generate the file ``primes\_1.txt'' again as in the previous exercise; and
-\item  open the this file; and
-\item  read it line by line; and
-\item  calculate the average of primes in the line; and
-\item  count the number of primes found per line; and
-\item  write it to the "primes\_2.txt" output file in the SCRATCH-directory.
+\item  Generate the file ``primes\_1.txt'' again as in the previous exercise; 
+\item  open the this file; 
+\item  read it line by line; 
+\item  calculate the average of primes in the line; 
+\item  count the number of primes found per line; 
+\item  write it to the ``primes\_2.txt'' output file in the \$VSC\_SCRATCH-directory.
 \end{enumerate}
 
 Check the Python and the PBS file, and submit the job:
@@ -361,6 +365,7 @@ Check the Python and the PBS file, and submit the job:
 \end{prompt}
 
 \section{How much disk space do I get?}
+\label{sect:how-much-disk-space-do-i-get}
 
 \subsection{Quota}
 
@@ -380,6 +385,7 @@ that there are also limits
 that can be made available to each individual \hpc user.
 
 The quota of disk space for each \hpc user is:
+
 \ifantwerpen
 \begin{tabular}{|p{0.7in}|p{1.0in}|} \hline
 \textbf{Volume} & \textbf{Quota per User} \\ \hline
@@ -398,30 +404,35 @@ SCRATCH         & 25 GB \\ \hline
 \fi
 
 The maximum numbers of files are:
+
 \ifantwerpen
 \begin{tabular}{|p{0.7in}|p{1.0in}|} \hline
 \textbf{Volume} & \textbf{Max. \# Files} \\ \hline
-DATA            & 100,000 \\ \hline
-HOME            & 20,000 \\ \hline
-SCRATCH         & 100,000 \\ \hline
+DATA            & 100000 \\ \hline
+HOME            & 20000 \\ \hline
+SCRATCH         & 100000 \\ \hline
 \end{tabular}
 \fi
 
 \ifgent
 \begin{tabular}{|p{0.7in}|p{1.0in}|} \hline
 \textbf{Volume} & \textbf{Max. \# Files} \\ \hline
-DATA            & 100,000 \\ \hline
-HOME            & 20,000 \\ \hline
-SCRATCH         & 100,000 \\ \hline
+DATA            & 100000 \\ \hline
+HOME            & 20000 \\ \hline
+SCRATCH         & 100000 \\ \hline
 \end{tabular}
 \fi
 
-\underbar{Tip:} The first action to take when you have exceeded your quota is
+\begin{tip}
+The first action to take when you have exceeded your quota is
 to clean up your directories. You could start by removing intermediate,
 temporary or log files.  Keeping your environment clean will never do any harm.
+\end{tip}
 
-\underbar{Tip:} Users can request for additional quota, which can be granted in
+\begin{tip}
+Users can request for additional quota, which can be granted in
 duly justified cases. Please contact the \hpc staff.
+\end{tip}
 
 \subsection{Check your quota}
 
@@ -444,7 +455,7 @@ Home          117   20000   25000        0   none
 Scratch        11  100000  150000       20   none
 \end{prompt}
 
-The ``\emph{show\_quota.py}'' commando has been developed to show you the
+The ``\emph{show\_quota.py}'' command has been developed to show you the
 status of your quota in a more readable format:
 
 \begin{prompt}
@@ -476,11 +487,11 @@ Usage}) command:
 \end{prompt}
 
 This shows you first the aggregated size of all subdirectories, and finally the
-total size of the current directory "." (this includes files stored in the
+total size of the current directory ``.'' (this includes files stored in the
 current directory).
 
-If you also want this size to be "human readable" (and not always the total
-number of kilobytes), you add the parameter "-h":
+If you also want this size to be ``human readable'' (and not always the total
+number of kilobytes), you add the parameter ``-h'':
 
 \begin{prompt}
 %\shellcmd{du -h}%
@@ -530,7 +541,7 @@ pass this directory as a parameter.
 \end{prompt}
 
 We also want to mention the \emph{tree} command, as it also provides an easy
-manner to see which files consumed your available quota's. \emph{Tree} is a
+manner to see which files consumed your available quotas. \emph{Tree} is a
 recursive directory-listing program that produces a depth indented listing of
 files.
 

--- a/intro-HPC/ch_torque_options.tex
+++ b/intro-HPC/ch_torque_options.tex
@@ -1,4 +1,5 @@
 \chapter{TORQUE options}
+\label{ch:torque-options}
 
 \section{TORQUE Submission Flags: common and useful directives}
 
@@ -6,10 +7,10 @@ Below is a list of the most common and useful directives.
 
 \begin{tabular}{|p{0.15\textwidth}|p{0.15\textwidth}|p{0.7\textwidth}|} \hline
 \strong{Option} & \strong{System type}  & \strong{Description} \\ \hline
--k              & All                   & Send "stdout" and/or "stderr" to your home directory when the job runs\newline \strong{\#PBS -k o} or \strong{\#PBS -k e} or \strong{\#PBS -koe}  \\ \hline
+-k              & All                   & Send ``stdout'' and/or ``stderr'' to your home directory when the job runs\newline \strong{\#PBS -k o} or \strong{\#PBS -k e} or \strong{\#PBS -koe}  \\ \hline
 -l              & All                   & Precedes a resource request, e.g., processors, wallclock \\ \hline
 -M              & All                   & Send an e-mail messages to an alternative e-mail address\newline \strong{\#PBS -M me@mymail.be} \\ \hline
--m              & All                   & Send an e-mail address when a job \strong{b}egins execution and/or \strong{e}nds or \strong{a}borts\newline \strong{\#PBS -m b} \strong{\#PBS -m be} \strong{\#PBS -m ba} \\ \hline
+-m              & All                   & Send an e-mail address when a job \strong{b}egins execution and/or \strong{e}nds or \strong{a}borts\newline \strong{\#PBS -m b} or \strong{\#PBS -m be} or \strong{\#PBS -m ba} \\ \hline
 mem             & Shared\newline Memory & Specifies the amount of memory you need for a job.\newline \strong{\#PBS -l mem=80gb} \\ \hline
 mpiprocs        & Clusters              & Number of processes per node on a cluster. This should equal number of processors on a node in most cases.\newline \strong{\#PBS -l mpiprocs=4} \\ \hline
 -N              & All                   & Give your job a unique name\newline \strong{\#PBS -N galaxies1234} \\ \hline

--- a/intro-HPC/ch_useful_linux_commands.tex
+++ b/intro-HPC/ch_useful_linux_commands.tex
@@ -1,8 +1,9 @@
 \chapter{Useful Linux Commands}
+\label{ch:useful-linux-commands}
 
 \section{Basic Linux Usage}
 
-All the \hpc clusters run the ``\operatingsystem'' operating system.  This
+All the \hpc clusters run the ``\operatingsystembase'' operating system.  This
 means that, when you connect to one of them, you get a command line interface,
 which looks something like this:
 
@@ -10,7 +11,7 @@ which looks something like this:
 %\userid{}%@ln01[203] $
 \end{prompt}
 
-When you see this, we also say you are inside a "shell". The shell will accept
+When you see this, we also say you are inside a ``shell''. The shell will accept
 your commands, and execute them.
 
 \begin{tabular}{|p{0.1\textwidth}|p{0.9\textwidth}|} \hline
@@ -22,21 +23,21 @@ echo & Prints its parameters to the screen \\ \hline
 \end{tabular}
 
 Most commands will accept or even need parameters, which are placed after the
-command, separated by spaces. A simple example with the 'echo' command:
+command, separated by spaces. A simple example with the ``echo'' command:
 
 \begin{prompt}
 %\shellcmd{echo This is a test}%
 This is a test
 \end{prompt}
 
-Important here is the "\$" sign in front of the first line. This should not be
-typed, but is a convention meaning "the rest of this line should be typed at
-your shell prompt". The lines not starting with the "\$" sign are usually the
+Important here is the ``\$'' sign in front of the first line. This should not be
+typed, but is a convention meaning ``the rest of this line should be typed at
+your shell prompt''. The lines not starting with the ``\$'' sign are usually the
 feedback or output from the command.
 
 More commands will be used in the rest of this text, and will be explained then
 if necessary. If not, you can usually get more information about a command, say
-the item or command 'ls', by trying either of the following:
+the item or command ``ls'', by trying either of the following:
 
 \begin{prompt}
 %\shellcmd{ls --help}%
@@ -44,7 +45,7 @@ the item or command 'ls', by trying either of the following:
 %\shellcmd{info ls}%
 \end{prompt}
 
-(You can exit the last two "manuals" by using the 'q' key.)
+(You can exit the last two ``manuals'' by using the ``q'' key.)
 For more exhaustive tutorials about Linux usage, please refer to the following sites:
 \url{http://www.linux.org/lessons/}
 \url{http://linux.about.com/od/nwb\_guide/a/gdenwb06.htm}
@@ -57,7 +58,7 @@ commands at any time by only issuing one command: starting the script.
 
 Scripts are basically non-compiled pieces of code: they are just text files.
 Since they don't contain machine code, they are executed by what is called a
-"parser" or an "interpreter". This is another program that understands the
+``parser'' or an ``interpreter''. This is another program that understands the
 command in the script, and converts them to machine code. There are many kinds
 of scripting languages, including Perl and Python.
 
@@ -83,22 +84,22 @@ Hello! This is my hostname:
 %\loginhost%
 \end{prompt}
 
-Suppose we want to call this script "foo". You open a new file for editing, and
-name it "foo", and edit it with your favorite editor
+Suppose we want to call this script ``foo''. You open a new file for editing, and
+name it ``foo'', and edit it with your favorite editor
 
 \begin{prompt}
 %\shellcmd{vi foo}%
 \end{prompt}
 
-or use the following commando's:
+or use the following commands:
 \begin{prompt}
 %\shellcmd{echo "echo Hello! This is my hostname:" $>$ foo}%
-%\shellcmd{echo hostname $>$$>$ foo }%
+%\shellcmd{echo hostname $>$$>$ foo}%
 \end{prompt}
 
 The easiest ways to run a script is by starting the interpreter and pass the
-script as parameter. In case of our script, the interpreter may either be 'sh'
-or 'bash' (which are the same on the cluster). So start the script:
+script as parameter. In case of our script, the interpreter may either be ``sh''
+or ``bash'' (which are the same on the cluster). So start the script:
 
 \begin{prompt}
 %\shellcmd{bash foo}%
@@ -112,10 +113,10 @@ A more advanced way of executing your shell scripts is by making them
 executable by their own, so without invoking the interpreter manually. The
 system can not automatically detect which interpreter you want, so you need to
 tell this in some way. The easiest way is by using the so called
-"shebang"-notation, explicitely created for this function: you put the
-following line on top of your shell script "\#!/path/to/your/interpreter".
+``shebang''-notation, explicitely created for this function: you put the
+following line on top of your shell script ``\#!/path/to/your/interpreter''.
 
-You can find this path with the "which" command. In our case, since we use bash
+You can find this path with the ``which'' command. In our case, since we use bash
 as an interpreter, we get the following path:
 
 \begin{prompt}
@@ -131,7 +132,7 @@ echo "Hello! This is my hostname:"
 hostname
 \end{code}
 
-Note that the "shebang" must be the first line of your script! Now the
+Note that the ``shebang'' must be the first line of your script! Now the
 operating system knows which program should be started to run the script.
 
 Finally, we tell the operating system that this script is now executable. For
@@ -151,7 +152,7 @@ Hello! This is my hostname:
 
 The same technique can be used for all other scripting languages, like Perl and Python.
 
-Most scripting languages understand that lines beginning with "\#" are
+Most scripting languages understand that lines beginning with ``\#'' are
 comments, and should be ignored. If the language you want to use does not
 ignore these lines, you may get strange results\ldots
 
@@ -216,7 +217,7 @@ man   & Displays the manual page of a command with its name, synopsis, descripti
 
 \begin{tabular}{|p{0.1\textwidth}|p{0.9\textwidth}|} \hline
 hostname  & show or set the system's host name \\ \hline
-ifconfig  & Display the current configuration of the network interface. It is also useful to get the information about IP address, Subnet Mask,set remote IP address , Netmask etc. \\ \hline
+ifconfig  & Display the current configuration of the network interface. It is also useful to get the information about IP address, subnet mask, set remote IP address, netmask etc. \\ \hline
 ping      & send ICMP ECHO\_REQUEST to network hosts, you will get back ICMP packet if the host responds.  This command is useful when you are in a doubt whether your computer is connected or not. \\ \hline
 \end{tabular}
 
@@ -233,7 +234,7 @@ whoami  & Displays the login name of the current effective user \\ \hline
 \subsection{Process Commands}
 
 \begin{tabular}{|p{0.1\textwidth}|p{0.9\textwidth}|} \hline
-\&      & In order to execute a command in the background, place an ampersand(\&)on the command line at the end of the command. A user job number(placed in brackets) and a system process number are displayed. A system process number is the number by which the system identifies the job whereas a user job number is the number by which the user identifies the job \\ \hline
+\&      & In order to execute a command in the background, place an ampersand (\&) on the command line at the end of the command. A user job number (placed in brackets) and a system process number are displayed. A system process number is the number by which the system identifies the job whereas a user job number is the number by which the user identifies the job \\ \hline
 at      & executes commands at a specified time \\ \hline
 bg      & Places a suspended job in the background \\ \hline
 crontab & crontab is a file which contains the schedule of entries to run at specified times \\ \hline

--- a/intro-HPC/examples/Compiling-and-testing-your-software-on-the-HPC/hello.pbs
+++ b/intro-HPC/examples/Compiling-and-testing-your-software-on-the-HPC/hello.pbs
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #PBS -N csub
-#PBS -q qshort
+#PBS -l walltime=01:00:00
 
 base=$PBS_O_WORKDIR
 exe="./hello"

--- a/intro-HPC/examples/Compiling-and-testing-your-software-on-the-HPC/mpihello.pbs
+++ b/intro-HPC/examples/Compiling-and-testing-your-software-on-the-HPC/mpihello.pbs
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 #PBS -N mpihello
-#PBS -q qshort
 #PBS -l walltime=00:05:00
 
   # assume a 16 core job
@@ -13,7 +12,6 @@ cd $PBS_O_WORKDIR
   # load the environment
 
 module purge
-module load ictce
-module load mpiexec
+module load intel
 
-mpiexec ./mpihello
+mpirun ./mpihello

--- a/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/T_hello.pbs
+++ b/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/T_hello.pbs
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-#PBS -q qshort
 #PBS -l walltime=00:05:00
 
   # This is a 8 core job

--- a/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/mpi_hello.pbs
+++ b/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/mpi_hello.pbs
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 #PBS -N mpihello
-#PBS -q qshort
 #PBS -l walltime=00:05:00
 
   # assume a 16 core job

--- a/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/omp1.pbs
+++ b/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/omp1.pbs
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-#PBS -q qshort
 #PBS -l walltime=00:05:00
 
   # This is a 8 core job

--- a/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/omp2.pbs
+++ b/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/omp2.pbs
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-#PBS -q qshort
 #PBS -l walltime=00:05:00
 
   # This is a 8 core job

--- a/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/omp3.pbs
+++ b/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/omp3.pbs
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-#PBS -q qshort
 #PBS -l walltime=00:05:00
 
   # This is a 8 core job

--- a/intro-HPC/examples/Multi-job-submission/par_sweep/weather.pbs
+++ b/intro-HPC/examples/Multi-job-submission/par_sweep/weather.pbs
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-#PBS -q qshort
 #PBS -l nodes=1:ppn=8
 #PBS -l walltime=04:00:00
 

--- a/intro-HPC/examples/Multi-job-submission/par_sweep/weather_p01.pbs
+++ b/intro-HPC/examples/Multi-job-submission/par_sweep/weather_p01.pbs
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-#PBS -q qshort
 #PBS -l nodes=1:ppn=8
 #PBS -l walltime=01:00:00
 

--- a/intro-HPC/examples/Program-examples/compile.txt
+++ b/intro-HPC/examples/Program-examples/compile.txt
@@ -1,6 +1,6 @@
 GCC/gfortran/...
 
-module load gogfl     # enables GCC, OpenMPI, (Sca)LAPACK ...
+module load foss     # enables GCC, OpenMPI, (Sca)LAPACK ...
 
 C compiler: gcc
 C++ compiler: g++
@@ -27,7 +27,7 @@ MPI example script:
 
 Intel suite
 
-module load ictce     # enables icc, ifort, Intel MPI, MKL, ...
+module load intel     # enables icc, ifort, Intel MPI, MKL, ...
 
 C compiler: icc
 C++ compiler: icpc

--- a/intro-HPC/examples/Running-jobs-with-input-output-data/file1a.pbs
+++ b/intro-HPC/examples/Running-jobs-with-input-output-data/file1a.pbs
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#PBS -q qshort
+#PBS -l walltime=00:05:00
 
 # go to the (current) working directory (optional, if this is the
 # directory where you submitted the job)

--- a/intro-HPC/examples/Running-jobs-with-input-output-data/file2.pbs
+++ b/intro-HPC/examples/Running-jobs-with-input-output-data/file2.pbs
@@ -1,10 +1,6 @@
 #!/bin/bash
 
 
-  # choose queue: qshort (1h), qreg (24h), qlong (72h), qxlong (168h)
-#PBS -q qshort
-
-
   # "name" of the job (optional)
 #PBS -N my_serial_job         
 

--- a/intro-HPC/examples/example.pbs
+++ b/intro-HPC/examples/example.pbs
@@ -1,31 +1,31 @@
 #!/bin/bash
 
 
-  # Choose the queue on which to submit the job
-  # The currently defined queues (with walltime) for the UA-HPC are:
-	#     qshort	1 hour
-	#     qreg	  1 day (24 hours)
-	#     qlong	  3 days (72 hours)
-	#     qxlong	7 days (168 hours)
-	#     qxxlong	21 days (502 hours)
-#PBS -q qshort
+  # Choose the appropriate walltime
+  # The currently walltime categories for the UA-HPC are:
+	#     1 hour
+	#     1 day (24 hours)
+	#     3 days (72 hours)
+	#     7 days (168 hours)
+	#     21 days (502 hours)
+   # syntax: [dd:]hh:mm:ss
+#PBS -l walltime=01:00:00
 
 
 	# Send "stdout" and/or "stderr" to your home directory when the job runs
 #PBS -k o    
-#PBS -k e    
-#PBS -koe  
+#PBS -k e
 
-  # send mail notification (optional)
+
+  # send mail notification (optional); may be combined, e.g., -m abe
   #   a        when job is aborted
   #   b        when job begins
   #   e        when job ends
-  #   M        your e-mail address (should always be specified)
-#PBS -m ae
-#PBS -M firstname.lastname@uantwerpen.be
+#PBS -m e
 
-	# Send an e-mail address when a job begins execution and/or ends or aborts
-#PBS -m b #PBS -m be #PBS -m ba
+  #   M        specify alternate e-mailaddress; default is your institute address
+# #PBS -M my.other.address@mail.com
+
 
   # specification (required!)
   #   nodes=   number of nodes; 1 for serial; 1 or more for parallel
@@ -57,11 +57,11 @@
 
 	# Number of compute nodes to use. 
 	# Usually combined with the mpiprocs directive
- #PBS -l select=2
+#PBS -l select=2
 
 	# Make sure that the environment in which the job runs is the same as 
 	# the environment in which it was submitted.
- #PBS -V
+#PBS -V
 
 	# Walltime: The maximum time a job can run before being stopped. 
 	# If not used a default of a few minutes is used. 

--- a/intro-HPC/examples/example.sh
+++ b/intro-HPC/examples/example.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
 
-  # choose queue: qshort (1h), qreg (24h), qlong (72h), qxlong (168h)
-#PBS -q qshort
-
-
   # "name" of the job (optional)
 #PBS -N my_serial_job         
 
@@ -23,13 +19,14 @@
 #  #PBS -l pvmem=16000m
 
 
-  # send mail notification (optional)
+  # send mail notification (optional); may be combined, e.g., -m abe
   #   a        when job is aborted
   #   b        when job begins
   #   e        when job ends
-  #   M        your e-mail address (should always be specified)
 #PBS -m e
-#PBS -M stefan.becuwe@ua.ac.be
+
+  #   M        specify alternate e-mailaddress; default is your institute address
+# #PBS -M my.other.address@mail.com
 
 
   # redirect standard output (-o) and error (-e) (optional)

--- a/intro-HPC/gent/ch_hpc_policies.tex
+++ b/intro-HPC/gent/ch_hpc_policies.tex
@@ -1,3 +1,4 @@
 \chapter{HPC Policies}
+\label{ch:hpc-policies}
 
 Stub chapter

--- a/intro-HPC/gent/ch_monitoring_utilization.tex
+++ b/intro-HPC/gent/ch_monitoring_utilization.tex
@@ -1,4 +1,5 @@
 \chapter{Monitoring Cluster Utilization}
+\label{ch:monitoring-cluster-utilization}
 
 % probably want to mention collectl
 Chapter still under construction.

--- a/intro-HPC/gent/contact-information.tex
+++ b/intro-HPC/gent/contact-information.tex
@@ -1,13 +1,13 @@
 \begin{enumerate}
 \item  By e-mail:  \hpcinfo
-\item  By Phone : 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert)
-\item  In real  : Campus Middelheim, Building G, Room G.309 and G.310
+\item  By phone: 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert)
+\item  In real: Campus Middelheim, Building G, Room G.309 and G.310
 \end{enumerate}
 
 Mailing-lists:
 
 \begin{enumerate}
 \item  Announcements: \hpcannounceml (for official announcements and communications)
-\item  Users : \hpcusersml (for discussions between users)
+\item  Users: \hpcusersml (for discussions between users)
 \end{enumerate}
 

--- a/intro-HPC/glossary.tex
+++ b/intro-HPC/glossary.tex
@@ -21,7 +21,7 @@
 \newglossaryentry{Distributed-memory-system}
 {
   name={Distributed memory system},
-  description={Computing system consisting of many compute nodes connected by a network, each with their own memory. Accessing memory on a neighboring node is possible but require explicit communication },
+  description={Computing system consisting of many compute nodes connected by a network, each with their own memory. Accessing memory on a neighboring node is possible but requires explicit communication},
 }
 \newglossaryentry{Flop}
 {
@@ -86,7 +86,7 @@
 \newglossaryentry{Modules}
 {
   name={Modules},
-  description={\hpc uses an open source software package called "Environment Modules," (Modules for short) which allows you to add various path definitions to your shell environment},
+  description={\hpc uses an open source software package called ``Environment Modules'' (Modules for short) which allows you to add various path definitions to your shell environment},
 }
 \newglossaryentry{MPI}
 {
@@ -96,7 +96,7 @@
 \newglossaryentry{Node}
 {
   name={Node},
-  description={Typically, a machine, one computer. A node is the fundamental object associated with compute resources. Each node contains the a list of},
+  description={Typically, a machine, one computer. A node is the fundamental object associated with compute resources.},
 }
 \newglossaryentry{Node-Attribute}
 {
@@ -116,7 +116,7 @@
 \newglossaryentry{Queues}
 {
   name={Queues},
-  description={PBS/TORQUE queues, or "classes," as Moab refers to them, represent groups of computing resources with specific parameters. A queue with a 12 hour runtime or "walltime" would allow jobs requesting 12 hours or less to use this queue},
+  description={PBS/TORQUE queues, or ``classes'' as Moab refers to them, represent groups of computing resources with specific parameters. A queue with a 12 hour runtime or ``walltime'' would allow jobs requesting 12 hours or less to use this queue},
 }
 \newglossaryentry{scp}
 {
@@ -126,7 +126,7 @@
 \newglossaryentry{Scratch}
 {
   name={Scratch},
-  description={Supercomputers generally have what is called scratch space: disk space available for temporary use. Use /scratch when, for example you are downloading and uncompressing applications, reading and writing input/output data during a batch job, or when you work with large datasets},
+  description={Supercomputers generally have what is called scratch space: disk space available for temporary use. Use the scratch filesystem when, for example you are downloading and uncompressing applications, reading and writing input/output data during a batch job, or when you work with large datasets},
 }
 \newglossaryentry{sftp}
 {
@@ -136,7 +136,7 @@
 \newglossaryentry{Shared-memory-system}
 {
   name={Shared memory system},
-  description={Computing system in which all of the processors share one global memory space. However, access times from a processor to different regions of memory are not necessarily uniform },
+  description={Computing system in which all of the processors share one global memory space. However, access times from a processor to different regions of memory are not necessarily uniform},
 }
 \newglossaryentry{SSH}
 {
@@ -148,14 +148,14 @@
   name={ssh-keys},
   description={OpenSSH is a network connectivity tool, which encrypts all traffic including passwords to effectively eliminate eavesdropping, connection hijacking, and other network-level attacks. SSH-keys are part of the OpenSSH bundle. On \hpc clusters, ssh-keys allow password-less access between compute nodes while running batch or interactive parallel jobs},
 }
-\newglossaryentry{super-computer}
+\newglossaryentry{Super-computer}
 {
-  name={super-computer},
+  name={Super-computer},
   description={A computer with an extremely high processing capacity or processing power},
 }
-\newglossaryentry{swap-space}
+\newglossaryentry{Swap-space}
 {
-  name={swap space},
+  name={Swap space},
   description={A quantity of virtual memory available for use by batch jobs. Swap is a consumable resource provided by nodes and consumed by jobs},
 }
 \newglossaryentry{Walltime}

--- a/intro-HPC/leuven/contact-information.tex
+++ b/intro-HPC/leuven/contact-information.tex
@@ -1,13 +1,13 @@
 \begin{enumerate}
 \item  By e-mail:  \hpcinfo
-\item  By Phone : 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert)
-\item  In real  : Campus Middelheim, Building G, Room G.309 and G.310
+\item  By phone: 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert)
+\item  In real: Campus Middelheim, Building G, Room G.309 and G.310
 \end{enumerate}
 
 Mailing-lists:
 
 \begin{enumerate}
 \item  Announcements: \hpcannounceml (for official announcements and communications)
-\item  Users : \hpcusersml (for discussions between users)
+\item  Users: \hpcusersml (for discussions between users)
 \end{enumerate}
 

--- a/intro-HPC/title.tex
+++ b/intro-HPC/title.tex
@@ -77,16 +77,16 @@ HPC.
 
 \begin{tabular}{|p{0.4\textwidth}|c|p{0.4\textwidth}|} \hline
 \multicolumn{3}{|c|}{\strong{Beginners Part}} \\ \hline
-\strong{Questions}                                                      & \strong{Chapter} & \strong{Title} \\ \hline
-What is a \hpc exactly?\newline Can it solve my computational needs?    & \strong{1} & Introduction to \hpc \\ \hline
-How to get an account?                                                  & \strong{2} & Getting an \hpc account \\ \hline
-How do I connect to the \hpc and transfer my files and programs?        & \strong{3} & Preparing the environment \\ \hline
-How to start background jobs?                                           & \strong{4} & Running batch jobs \\ \hline
-How to start jobs with user interaction?                                & \strong{5} & Running interactive jobs \\ \hline
-Where do the input and output go? Where to collect my results?          & \strong{6} & Running jobs with input/output data \\ \hline
-Can I speed up my program by exploring parallel programming techniques? & \strong{7} & Multi-core jobs / Parallel programming \\ \hline
-Can I start many jobs at once?                                          & \strong{8} & Multi job submission \\ \hline
-What are the rules and priorities of jobs?                              & \strong{9} & HPC policies \\ \hline
+\strong{Questions}                                                      & \strong{chapter} & \strong{title} \\ \hline
+What is a \hpc exactly?\newline Can it solve my computational needs?    & \strong{\ref{ch:introduction-to-hpc}} & \nameref{ch:introduction-to-hpc}} \\ \hline
+How to get an account?                                                  & \strong{\ref{ch:getting-a-hpc-account}} & \nameref{ch:getting-a-hpc-account}} \\ \hline
+How do I connect to the \hpc and transfer my files and programs?        & \strong{\ref{ch:preparing-the-environment}} & \nameref{ch:preparing-the-environment}} \\ \hline
+How to start background jobs?                                           & \strong{\ref{ch:running-batch-jobs}} & \nameref{ch:running-batch-jobs}} \\ \hline
+How to start jobs with user interaction?                                & \strong{\ref{ch:running-interactive-jobs}} & \nameref{ch:running-interactive-jobs}} \\ \hline
+Where do the input and output go? Where to collect my results?          & \strong{\ref{ch:running-jobs-with-input-output-data}} & \nameref{ch:running-jobs-with-input-output-data}} \\ \hline
+Can I speed up my program by exploring parallel programming techniques? & \strong{\ref{ch:multi-core-jobs-parallel-computing}} & \nameref{ch:multi-core-jobs-parallel-computing}} \\ \hline
+Can I start many jobs at once?                                          & \strong{\ref{ch:multi-job-submission}} & \nameref{ch:multi-job-submission}} \\ \hline
+What are the rules and priorities of jobs?                              & \strong{\ref{ch:hpc-policies}} & \nameref{ch:hpc-policies} \\ \hline
 \end{tabular}
 
 The \strong{Advanced Part} focuses on in-depth issues. The aim is to assist the
@@ -94,23 +94,23 @@ end-user in running his own software on the \hpc.
 
 \begin{tabular}{|p{0.4\textwidth}|c|p{0.4\textwidth}|} \hline
 \multicolumn{3}{|c|}{\strong{Advanced Part}} \\ \hline
-\strong{Questions}                           & \strong{Chapter} & \strong{Title} \\ \hline
-Can I compile my software on the \hpc?       & \strong{10}      & Compiling on the \hpc \\ \hline
-What are the optimal Job Specifications?     & \strong{11}      & Fine-tuning Job Specifications \\ \hline
-How do I check my programs at runtime?       & \strong{12}      & Monitoring \hpc Utilization with Ganglia \\ \hline
-Can I stop my program and continue later on? & \strong{13}      & Checkpointing \\ \hline
-Do you have more examples for me?            & \strong{14}      & Examples \\ \hline
-Any more advice?                             & \strong{15}      & Good practices \\ \hline
+\strong{Questions}                           & \strong{chapter} & \strong{title} \\ \hline
+Can I compile my software on the \hpc?       & \strong{\ref{ch:compiling-and-testing-your-software-on-the-hpc}}      & \nameref{ch:compiling-and-testing-your-software-on-the-hpc} \\ \hline
+What are the optimal Job Specifications?     & \strong{\ref{ch:fine-tuning-job-specifications}}      & \nameref{ch:fine-tuning-job-specifications} \\ \hline
+How do I check my programs at runtime?       & \strong{\ref{ch:monitoring-cluster-utilization}}      & \nameref{ch:monitoring-cluster-utilization} \\ \hline
+Can I stop my program and continue later on? & \strong{\ref{ch:checkpointing}}      & Checkpointing \\ \hline
+Do you have more examples for me?            & \strong{\ref{ch:program-examples}}      & \nameref{ch:program-examples} \\ \hline
+Any more advice?                             & \strong{\ref{ch:good-practices}}      & Good practices \\ \hline
 \end{tabular}
 
 The \strong{Annexes} contains some useful reference guides.
 
 \begin{tabular}{|l|c|} \hline
 \multicolumn{2}{|c|}{\strong{Annex}} \\ \hline
-\strong{Title}             & \strong{Chapter} \\ \hline
-\hpc Quick Reference Guide & \strong{16} \\ \hline
-Torque Options             & \strong{17} \\ \hline
-Useful Linux commands      & \strong{18} \\ \hline
+\strong{Title}             & \strong{chapter} \\ \hline
+\nameref{ch:quick-reference-guide} & \strong{\ref{ch:quick-reference-guide}} \\ \hline
+\nameref{ch:torque-options}& \strong{\ref{ch:torque-options}} \\ \hline
+\nameref{ch:useful-linux-commands}& \strong{\ref{ch:useful-linux-commands}} \\ \hline
 \end{tabular}
 
 
@@ -121,20 +121,22 @@ In this tutorial specific commands are separated from the accompanying text:
 \begin{prompt}
 %\shellcmd{Commands}%
 \end{prompt}
-They have to be entered by the reader at a command line in a Terminal on the \hpc. They appear in all exercise preceded by a \$ and printed in \textbf{bold}. You'll find those actions in a grey frame.
+They have to be entered by the reader at a command line in a Terminal on the \hpc. They appear in all exercises preceded by a \$ and printed in \textbf{bold}. You'll find those actions in a grey frame.
 
-\strong{<Button>} are menus, buttons or drop down boxes to be presses or selected.
+\keys{Button} are menus, buttons or drop down boxes to be pressed or selected.
 
-\strong{`Directory'} is the notation for directories (called ``folders'' in
-Windows terminology) or specific files. (e.g., `\homedir')
+\strong{``Directory''} is the notation for directories (called ``folders'' in
+Windows terminology) or specific files. (e.g., ``\homedir'')
 
 \strong{``Text''} Is the notation for text to be entered.
 
-\strong{Tip:} A ``Tip'' paragraph is used for remarks or tips.
+\begin{tip}
+A ``Tip'' paragraph is used for remarks or tips.
+\end{tip}
 
 \strong{\underbar{More support:}}
 
-Before starting the course, the example programs and configuration files used in this \hpc Tutorial must be copied to your home directory, so that you can work on your personal copy. If you have received a new VSC-account, all examples are present in an `\examplesdir' directory.
+Before starting the course, the example programs and configuration files used in this \hpc Tutorial must be copied to your home directory, so that you can work on your personal copy. If you have received a new VSC-account, all examples are present in an ``\examplesdir'' directory.
 
 \begin{prompt}
 %\shellcmd{cp --r \examplesdir \tilde/}%
@@ -145,30 +147,25 @@ Before starting the course, the example programs and configuration files used in
 They can also be downloaded from the VSC website at https://www.vscentrum.be.  Apart from this \hpc Tutorial, the \hpc documentation on the web (https://www.vscentrum.be) will serve as a reference for all the \hpc operations.
 
 
-\strong{\underbar{Tip:}} The users are advised to get self-organized. There are
+\begin{tip}
+The users are advised to get self-organized. There are
 only limited resources available at the \hpc, which are best effort based.
 The \hpc cannot give support for code fixing, the user applications and own
 developed software remain solely the responsibility of the end-user.
+\end{tip}
 
 More documentation can be found at:
 
 \begin{enumerate}
   \item  VSC documentation: \url{https://www.vscentrum.be/vsc-help-center}
-  \item  External documentation: \url{http://www.adaptivecomputing.com}
-\end{enumerate}
-
-Manuals (Torque, MOAB):
-
-\begin{enumerate}
-  \item  Torque: \url{http://docs.adaptivecomputing.com/torque/help.htm}
-  \item  MOAB: \url{http://docs.adaptivecomputing.com/mwm/help.htm}
+  \item  External documentation (TORQUE, Moab): \url{http://docs.adaptivecomputing.com}
 \end{enumerate}
 
 This tutorial \strong{(\version)} is intended for users working on \strong{\OS} who want to connect to the HPC of the \strong{\university}.
 
-This tutorial is also available in a specific Windows, Mac or Linux version.
+This tutorial is available in a Windows, Mac or Linux version.
 
-This tutorial is also available for UAntwerpen, UGent, KULeuven, UHasselt and VUB users.
+This tutorial is available for UAntwerpen, UGent, KULeuven, UHasselt and VUB users.
 
 Request your appropriate version at \hpcinfo.
 

--- a/perfexpert/ch01_introduction.tex
+++ b/perfexpert/ch01_introduction.tex
@@ -10,7 +10,7 @@ The previously available \strong{performance optimization tools} require conside
 \begin{enumerate}
   \item  \strong{Detect} and \strong{diagnosis} the causes for typical core, socket, and node-level performance bottlenecks in procedures and loops of an application;
   \item  Apply \strong{pattern-based software transformations} on the application source code to enhance performance on identified bottlenecks;
-  \item  Provide \strong{performance analysis report} and \strong{suggestions for remediation }for application's performance bottlenecks, which compilers are unable to apply automatically.
+  \item  Provide \strong{performance analysis report} and \strong{suggestions for remediation} for application's performance bottlenecks, which compilers are unable to apply automatically.
 \end{enumerate}
 
 PerfExpert was developed at the Texas Advanced Computing Center (\strong{TACC}) as an easy to use tool for diagnosing the performance of scientific applications. While most profiler tools give a sense of \strong{where} performance bottlenecks and hotspots occur, PerfExpert aims to explain \strong{why}, even going so far as to provide relevant code modification suggestions that could improve performance.
@@ -20,7 +20,7 @@ PerfExpert was developed at the Texas Advanced Computing Center (\strong{TACC}) 
 
 The performance of scientific computing applications is heavily influenced by memory access and floating-point unit (FPU) utilization. Many modern CPUs contain a variety of hardware performance counter events that are useful in diagnosing resource utilization and access patterns. These counters capture events such as L1 and L2 cache misses, branch instruction mispredictions, and execution of floating point instructions. PerfExpert collects these statistics and attempts to correlate them with the code being analyzed. Thus, individual functions or even separate loop nests can be characterized in terms of the kinds of CPU instructions and memory accesses they produce.
 
-PerfExpert is built on top of two profiling tools that provide access to the \strong{timing }and\strong{ hardware performance counter events figures}: PAPI and HPCToolkit.
+PerfExpert is built on top of two profiling tools that provide access to the \strong{timing} and \strong{hardware performance counter events figures}: PAPI and HPCToolkit.
 
 \begin{enumerate}
   \item  \strong{PAPI} is a library that provides access to CPU hardware performance counter events. Because the implementation of performance counters differs across CPU manufacturers and models, PAPI provides an abstracted interface that allows the user to retrieve the desired information regardless of the underlying OS or CPU architecture.
@@ -61,7 +61,7 @@ For the exercises in this tutorial, we request interactive access on a compute n
 \end{prompt}
 \fi
 
-PerfExpert depends on HPCToolkit, and PAPI library, thus it requires the papi, hpctoolkit, and perfexpert modules to be loaded. The "module help" command provides additional information.
+PerfExpert depends on HPCToolkit, and PAPI library, thus it requires the papi, hpctoolkit, and perfexpert modules to be loaded. The ``module help'' command provides additional information.
 
 And load the appropriate modules:
 \iftacc

--- a/perfexpert/ch02_profiling.tex
+++ b/perfexpert/ch02_profiling.tex
@@ -2,7 +2,10 @@
 \label{ch:ch02_profiling}
 
 \renewcommand{\exampledir}{examples/ch02-profiling}
-\emph{Tip: Find the source code for the examples in this Chapter in the directory:  ``\tilde/\exampledir''.}
+
+\begin{tip}
+Find the source code for the examples in this Chapter in the directory:  ``\tilde/\exampledir''.
+\end{tip}
 
 \section{Profiling Strategy}
 \label{sec:Profiling_Strategy}
@@ -10,7 +13,7 @@
 \subsection{Introduction}
 \label{subsec:Introduction}
 
-\emph{Profiling} ("program profiling", "software profiling") is a form of dynamic program analysis that measures, for example, the space (memory) or time complexity of a program, the usage of particular instructions, or frequency and duration of function calls. The most common use of profiling information is to aid program optimization. Non-optimized programs will needlessly consume more computer resources on Stampede (computational, storage, network), which could otherwise reduce the execution time of your application or be made available to other users. Profiling can also help you find many other statistics through which many potential bugs can be spotted and sorted out. All users of Stampede are highly encouraged to profile their applications, before using the computing facilities.
+\emph{Profiling} (``program profiling'', ``software profiling'') is a form of dynamic program analysis that measures, for example, the space (memory) or time complexity of a program, the usage of particular instructions, or frequency and duration of function calls. The most common use of profiling information is to aid program optimization. Non-optimized programs will needlessly consume more computer resources on Stampede (computational, storage, network), which could otherwise reduce the execution time of your application or be made available to other users. Profiling can also help you find many other statistics through which many potential bugs can be spotted and sorted out. All users of Stampede are highly encouraged to profile their applications, before using the computing facilities.
 
 Profiling is achieved by instrumenting either the program source code or its binary executable form using a tool called a \emph{profiler} (or \emph{code profiler}). Profilers, which are also programs themselves, analyze target programs by collecting information on their execution. Since profilers interrupt program execution to collect information, they have a finite resolution in the time measurements, which should be taken with a grain of salt.
 
@@ -29,7 +32,7 @@ Source-code performance optimization has four stages:
 
 \begin{enumerate}
   \item  \emph{measurement},
-  \item  \emph{analysis and diagnosis of bottlenecks,}
+  \item  \emph{analysis and diagnosis of bottlenecks},
   \item  determination of \emph{optimizations}, and
   \item  \emph{rewriting source code}.
 \end{enumerate}
@@ -132,20 +135,26 @@ You notice that:
 
 In this run, PerfExpert was not able to relate each hotspot with its exact location (line number) in source file because this information was not available in the object file. Programs compiled with the ``-g'' option will have debug information in the generated binary files, and PerfExpert will be able to report very specific on the line-number and source-file where a certain hotspot occurred.
 
-\emph{Tip:} Always compile your programs with the debug option (-g) on.
-\emph{Tip:} If you using gcc 4.8 or newer, you should use -gdwarf-3 option!
+\begin{tip}
+Always compile your programs with the debug option (-g) on.
+\end{tip}
+
+\begin{tip}
+If you using gcc 4.8 or newer, you should use -gdwarf-3 option!
+\end{tip}
+
 
 Apart from the total running time, PerfExpert performance analysis report includes, for each hotspot (i.e., for each subroutine above the threshold):
 
 \begin{enumerate}
   \item  \emph{Efficiency of the Subroutine}
   \begin{enumerate}
-    \item \emph{ }Instruction execution ratios (with respect to total instructions);
+    \item Instruction execution ratios (with respect to total instructions);
     \item  Computational efficiency (GFLOPs measurements);
   \end{enumerate}
   \item  \emph{LCPI Performance assessment}
   \begin{enumerate}
-    \item \emph{ }Overall performance;
+    \item Overall performance;
     \item  Values for 6 categories:
     \begin{enumerate}
       \item  Data access
@@ -177,8 +186,8 @@ A software program spend its time on 3 types of instructions:
 \begin{enumerate}
   \item  \strong{Computations}: Typically, we want our program to be busy with computations (floating-point or other) to solve our scientific problem, and as such a high percentage for FP computations is considered to be good and desired.
   \item  \strong{Data Access:} The computations will need to read input data and will generate output data. Data access (preferably from the fastest lowest cache levels) is needed, but the overall times spend on reading and writing data shall be limited as it is not the core goal of our program. A high percentage of time spend on data access might indicate data access issues.
-  \item  \strong{Program logic:} The time spent on other instructions (control flow, testing, loops, branching) can be considered as a `waste' of time and should be low. In most applications, this amount is very low, and as such we do not generate metrics for them. The percentages for \emph{Computations}, \emph{Data Access }and \emph{Program Logic} 
-  should total 100\%\footnote{ $ Some\ architectures\ such\ as\ Intel\ Sandy\ Bridge,\ Intel\ Ivy\ Bridge,\ and\ Intel\ Haswell\ does\ not\ provide accurate\ values\ in\ their\ performance\ counter\ events,\ specially\ for\ the\ floating-point\ instructions.\ For\ that\ reason,\ it\ is\ possible\ to\ see\ application\ with\ more\ than\ 100\%\ of\ floating-point\ instruction,\ with\ is\ obviously\ not\ possible.$ }, so we can easily estimate the \% for this category.
+  \item  \strong{Program logic:} The time spent on other instructions (control flow, testing, loops, branching) can be considered as a ``waste'' of time and should be low. In most applications, this amount is very low, and as such we do not generate metrics for them. The percentages for \emph{Computations}, \emph{Data Access} and \emph{Program Logic} 
+  should total 100\%\footnote{Some architectures such as Intel Sandy Bridge, Intel Ivy Bridge, and Intel Haswell does not provide accurate values in their performance counter events, specially for the floating-point instructions. For that reason, it is possible to see application with more than 100\% of floating-point instruction, with is obviously not possible.}, so we can easily estimate the \% for this category.
 \end{enumerate}
 
 These ratios gives a rough estimate in trying to understand whether optimizing the program for either \emph{data accesses} or \emph{floating-point instructions} would have a significant impact on the total running time of the program.
@@ -197,7 +206,7 @@ In the previous Matrix-Multiplication example, our GFLOP values were:
 
 The higher the GFLOPS percentage, the more efficient are computations are done. Although it is rare for real-world programs to match even 50\% of the maximum value, this metric can serve as an estimate of how efficiently the code performs computations.
 
-This performance report gives us also an indication about the `vectorization degree', i.e., the percentage of the computations that were ``vectorized'' (=packed) and run in parallel.
+This performance report gives us also an indication about the ``vectorization degree'', i.e., the percentage of the computations that were ``vectorized'' (=packed) and run in parallel.
 
 \begin{prompt}
 * GFLOPS (%\%% max)        12.5 ******
@@ -210,7 +219,7 @@ This performance report gives us also an indication about the `vectorization deg
   \item  \emph{Scalar}: This represents the \% of FP instructions which were not vectorized. These computations were executed one by one in serial mode and the value should be low.
 \end{enumerate}
 
-You noticed that the Matrix Multiplication program was not able to \emph{`vectorize'} (Packed was 0\%) and that all our FP computations were executed sequentially (Scalar was 12.5 \%).
+You noticed that the Matrix Multiplication program was not able to \emph{`vectorize'} (Packed was 0\%) and that all our FP computations were executed sequentially (Scalar was 12.5\%).
 
 \section{Profiling the LCPI Performance Categories}
 \label{sec:Profiling_the_LCPI_Performance_Categories}
@@ -231,7 +240,7 @@ The LCPI value is a good indicator of the cost arising from instructions of the 
 
 \emph{Hence, the higher the LCPI, the slower the program.}
 
-Generally, a value of 0.5 or lower for an LCPI is considered to be good. However, it is only necessary to look at the ratings (good, okay, ..., bad).
+Generally, a value of 0.5 or lower for an LCPI is considered to be good. However, it is only necessary to look at the ratings (good, okay, \ldots, bad).
 
 The rest of the report maps this overall LCPI, into the six constituent categories: \emph{data accesses}, \emph{instruction accesses}, \emph{data TLB accesses}, \emph{instruction TLB accesses}, \emph{branches} and \emph{floating point computations}. Without getting into the details of instruction operation on Intel and AMD chips, one can say that these six categories record performance in non-overlapping ways. That is, they roughly represent six separate categories of performance for any application.
 
@@ -241,11 +250,11 @@ Individual machine instructions or events can vary between architectures, and ar
 
 In each case, the classification (data access, instruction access, data TLB, etc.) is shown so that it is easy to understand which category is responsible for the performance slowdown. For instance if the overall LCPI is poor and the data access LCPI is high, then you should concentrate on improving the access to program variables and memory. Additional LCPI details help in relating performance numbers to the process architecture.
 
-While high LCPI values may indicate costly and inefficient use of certain computing resources, they do not specify what should be done to make the code segment more efficient. PerfExpert uses a set of rules, which map the LCPI metric values to one or more specific modifications (recommendations or suggestions for optimization) to the code segment to correct the inefficiency in the code segment. We will discuss this recommendation system later in Chapter 4.
+While high LCPI values may indicate costly and inefficient use of certain computing resources, they do not specify what should be done to make the code segment more efficient. PerfExpert uses a set of rules, which map the LCPI metric values to one or more specific modifications (recommendations or suggestions for optimization) to the code segment to correct the inefficiency in the code segment. We will discuss this recommendation system later in~\autoref{ch:ch04_multi_core_multi_node_profiling}.
 
 Before we can enhance or speed-up your own program, you must fully be able to interpret the performance report. We will use some lab exercises to build up this competence.
 
-We will change the matrix multiplication program in an `evil' manner, to deliberately generate bad performance reports. The goal is to let the user understand the potential causes of bad performance and to teach him to interpret the performance report.
+We will change the matrix multiplication program in an ``evil'' manner, to deliberately generate bad performance reports. The goal is to let the user understand the potential causes of bad performance and to teach him to interpret the performance report.
 
 \subsection{Category \#1: Data Access}
 \label{subsec:CAT1_Data_Access}
@@ -279,7 +288,7 @@ The ``-c'' option in PerfExpert will print colors.
 
 \begin{prompt}
 %\shellcmd{gcc -g -o test1 test1.c}%
-%\shellcmd{ perfexpert -c 0.9 ./test1}%
+%\shellcmd{perfexpert -c 0.9 ./test1}%
 [perfexpert] Collecting measurements [hpctoolkit]
 [perfexpert]    [1] 20.045568079 seconds (includes measurement overhead)
 [perfexpert]    [2] 21.401645102 seconds (includes measurement overhead)
@@ -333,9 +342,11 @@ We notice that:
   \item We have quite a lot of \emph{floating point instructions}. This was expected, as it was the core functionality of our program. We only have \emph{fast} Floating Point instructions, as we did not program many ``expensive'' (slow) divisions and/or square-roots calculations.
 \end{enumerate}
 
-This \emph{analysis} indicates a \emph{performance problem related to data access} in the ``compute'' function. This function is responsible for 99,98\% of the total runtime, so an improvement might heavily impact to total runtime.
+This \emph{analysis} indicates a \emph{performance problem related to data access} in the ``compute'' function. This function is responsible for 99.98\% of the total runtime, so an improvement might heavily impact to total runtime.
 
-\emph{Tip:} It is interesting to run this example with full (-O3) and without (-O0) compiler optimization and check the difference in runtime.
+\begin{tip}
+It is interesting to run this example with full (-O3) and without (-O0) compiler optimization and check the difference in runtime.
+\end{tip}
 
 \begin{prompt}
 %\shellcmd{gcc -O3 -g -o test1 test1.c}%
@@ -433,7 +444,7 @@ performance assessment  LCPI good.......okay.......fair.......poor.......bad
 
 ============================================================================
 
-As aforementioned, mappings between virtual and physical memory are facilitated by a page table, which is kept in memory. To minimize references to this table, recently-used portions of the page table are cached in a hierarchy of 'translation lookaside buffers', or TLBs, which are consulted on every virtual address translation. As with data caches, the farther a request has to go to be satisfied, the worse the performance impact. These metric estimates the performance penalty paid for missing the first-level data TLB (DTLB) that includes hitting in the second-level data TLB (STLB) as well as performing a hardware page walks on an STLB miss.
+As aforementioned, mappings between virtual and physical memory are facilitated by a page table, which is kept in memory. To minimize references to this table, recently-used portions of the page table are cached in a hierarchy of ``translation lookaside buffers'', or TLBs, which are consulted on every virtual address translation. As with data caches, the farther a request has to go to be satisfied, the worse the performance impact. These metric estimates the performance penalty paid for missing the first-level data TLB (DTLB) that includes hitting in the second-level data TLB (STLB) as well as performing a hardware page walks on an STLB miss.
 
 We notice that:
 
@@ -473,7 +484,7 @@ In modern CPUs, the processor tries and fetches instructions from memory before 
 Branches (i.e., conditional jumps) present a difficulty for the processor pipeline. After fetching a branch instruction, the processor needs to fetch the next instruction. But, there are \emph{multiple possible} ``next'' instructions! The processor won't be sure which instruction is the next one until the branching instruction makes it to the end of the pipeline.
 
 Instead of stalling the pipeline until the branching instruction is fully executed, modern processors attempt to \emph{predict} whether the jump will or will not be taken. Then, the processor can fetch the instruction that it thinks is the next one. If the prediction turns out wrong, the processor will simply discard the partially executed instructions that are in the pipeline and the pipeline starts over with the correct branch, 
-incurring a delay\footnote{ $ There\ is\ another\ technique\ known\ as\ ``speculative\ execution''\ which\ actually\ executes\ more\ than\ one\ branch\ possibility,\ however,\ this\ tutorial\ is\ not\ intended\ to\ cover\ this\ technique.$ }.
+incurring a delay.\footnote{There is another technique known as ``speculative execution'' which actually executes more than one branch possibility, however, this tutorial is not intended to cover this technique.}
 
 The \emph{test5a} program will create a large array of randomly obtained values of 0's, 1's, 2's and 3's. We loop through the array and branch for each value, doing time-wasting work. As all the values were randomly obtained, we expect that the computer is not able to predict (find a pattern) in the branches.
 
@@ -652,7 +663,7 @@ We notice in this example that:
   \item  But we have a lot of \emph{floating point instructions}. This was expected, as it was the core functionality of our program. We have a considerable amount of \emph{slow} Floating Point instructions (division and square-root), which will be causing the slow performance.
 \end{enumerate}
 
-This \emph{analysis} indicates a \emph{performance }issue related to the\emph{ slow floating-point calculations}. Just the square root operations (calls to libm) are responsible for 28\% of the runtime, so an improvement might heavily impact to total runtime.
+This \emph{analysis} indicates a \emph{performance} issue related to the \emph{slow floating-point calculations}. Just the square root operations (calls to libm) are responsible for 28\% of the runtime, so an improvement might heavily impact to total runtime.
 
 As a general rule of thumb: Both floating-point division and square root are considered as slow operations. Addition, subtraction and multiplication are fast FP operations. Square root can be expect to be approximately the same speed or somewhat slower (i.e., approx. 1x - 2x lower performance) compared to a division.
 

--- a/perfexpert/ch03_optimizing.tex
+++ b/perfexpert/ch03_optimizing.tex
@@ -2,7 +2,10 @@
 \label{ch:ch03_optimizing}
 
 \renewcommand{\exampledir}{examples/ch03-optimizing}
-\strong{Tip: Find the source code for the examples in this Chapter in the directory:  ``\tilde/\exampledir''.}
+
+\begin{tip}
+Find the source code for the examples in this chapter in the directory:  ``\tilde/\exampledir''.
+\end{tip}
 
 First we, go to the directory of the examples of Chapter03:
 
@@ -38,7 +41,7 @@ PerfExpert can sort the hotspots according to:
 \begin{enumerate}
   \item  \strong{Relevance}: Sorted according to their relevance in \% of the total runtime. The code blocks were the execution time is higher will be presented on top. But those code blocks might already be programmed in a full professional and well-performing manner, and maybe cannot be optimized anymore.
   \item  \strong{Performance}: Sorted according to their performance. The code blocks with the worst performance will be presented on top. These code blocks bears the potential to generate the best performance improvement.
-  \item  \strong{Mixed or Impact: }Sorted according to the formula \emph{Relevance x Performance}. The code blocks with a combination of the worst performance and longest execution times (thus having the highest \emph{impact}) are presented on top. Those are the best candidates for optimization.
+  \item  \strong{Mixed or Impact:} Sorted according to the formula \emph{Relevance x Performance}. The code blocks with a combination of the worst performance and longest execution times (thus having the highest \emph{impact}) are presented on top. Those are the best candidates for optimization.
 \end{enumerate}
 
 By default, PerfExpert will list its hotspots unsorted.
@@ -121,8 +124,8 @@ And compile and run PerfExpert.
 The ``-c'' option in PerfExpert will print colors.
 
 \begin{prompt}
-%\shellcmd{ gcc -g -o mm1 mm1.c}%
-%\shellcmd{ perfexpert -c 0.9 ./mm1}%
+%\shellcmd{gcc -g -o mm1 mm1.c}%
+%\shellcmd{perfexpert -c 0.9 ./mm1}%
 ...
 Loop in function compute in mm1.c:12 (99.76%\%% of the total runtime)
 ============================================================================
@@ -134,14 +137,14 @@ ratio to total instrns    %\%%  0..........25.........50.........75.........100
 ...
 \end{prompt}
 
-We have now avoided the reference to our matrices `a' and `b' inside the loop. You see that the percentage of time needed for data accesses was reduced to zero.
+We have now avoided the reference to our matrices ``a'' and ``b'' inside the loop. You see that the percentage of time needed for data accesses was reduced to zero.
 
 \strong{Note:} Of course, your program needs to perform the work. It is not always acceptable to reduce the amount of time spent on data access by just not doing any useful computation!
 
 \subsection{Optimizing the Computational Efficiency (GFLOPS)}
 \label{subsec:Optimizing_Computational_Efficiancy}
 
-In our Matrix-Multiplication example of Chapter 2, we noticed that the Matrix Multiplication program was not able to vectorize (Packed was 0\%), all computation were sequential (Scalar was 12.5 \%).
+In our Matrix-Multiplication example of \autoref{ch:ch02_profiling}, we noticed that the Matrix Multiplication program was not able to vectorize (Packed was 0\%), all computation were sequential (Scalar was 12.5\%).
 
 But remember that we have compiled the program without any specific \textit{Optimization} option. The GCC compiler uses level 1 (-O1) as its default ``Optimization level''!
 
@@ -159,7 +162,7 @@ Now, lets see what happens if we would compile the same program with FULL optimi
 
 The program is now able to \textit{`vectorize'} much better.
 
-Of course, in the first place we need to design our program in such a way that the compiler is able to vectorize. A situation where we create a read/write data dependency within the loop (e.g.: for ...  \{ a[i+1] = a[i] * c[i]; \} ) shall be avoided, as such program logic may not allow the compiler to `vectorize' this loop.
+Of course, in the first place we need to design our program in such a way that the compiler is able to vectorize. A situation where we create a read/write data dependency within the loop (e.g., for \ldots\  \{ a[i+1] = a[i] * c[i]; \} ) shall be avoided, as such program logic may not allow the compiler to ``vectorize'' this loop.
 
 \section{Optimizing the LCPI Performance Categories}
 \label{sec:Optimizing_the_LCPI_Performance_Categories}
@@ -167,14 +170,14 @@ Of course, in the first place we need to design our program in such a way that t
 \subsection{Category \#1: Data Access}
 \label{subsec:CAT1_Data_Access}
 
-These kinds of issues occur regularly. The \emph{typical issues }are that\emph{ }a high number of CPU cycles are being spent, whilst waiting for LLC load misses to be serviced.
+These kinds of issues occur regularly. The \emph{typical issues} are that a high number of CPU cycles are being spent, whilst waiting for LLC load misses to be serviced.
 
 In general, \emph{some possible optimizations} to improve \emph{data access locality} are:
 
 \begin{enumerate}
   \item  to redesign the data structure;
   \item  to reduce data working set size;
-  \item  to reorder or interchange the loops, (this works when the loop execution is not important, but one must be aware that FORTRAN accesses storage by column, C by row);
+  \item  to reorder or interchange the loops, (this works when the loop execution is not important, but one must be aware that Fortran accesses storage by column, C by row);
   \item  to perform loop fusion (Takes two adjacent loops that have same iteration and combines them into a single loop);
   \item  to block and consuming data in chunks that fit in the LLC;
   \item  to explore hardware pre-fetchers. (Frequently, the CPU is not fed fast enough with data from memory, which causes a bottleneck resulting in a CPU waiting for data to process).
@@ -332,7 +335,7 @@ for (i = 0; i < n; i++)
 %\shellcmd{perfexpert -c 0.6 ./test3\_i1}%
 \end{prompt}
 
-And note the improvement, isn't it quite ...  spectacular?
+And note the improvement, isn't it quite \ldots\  spectacular?
 
 \subsection{Category \#4: Instruction TLB}
 \label{subsec:CAT4_Optimizing_Instruction_TLB}
@@ -350,7 +353,7 @@ Potential solutions are:
 \subsection{Category \#5: Branches}
 \label{subsec:CAT5_Optimizing_Branches}
 
-Branch prediction is a feature of the hardware, and not of the compiler\footnote{ $\ Although\ it\ is\ possible\ to\ insert\ compiler-specific\ annotations\ (aka\ pragmas)\ to\ tell\ the\ compiler\\ which\ is\ the\ most\ occurring\ branch\ result.$ }.
+Branch prediction is a feature of the hardware, and not of the compiler.\footnote{Although it is possible to insert compiler-specific annotations (aka pragmas) to tell the compiler which is the most occurring branch result.}
 
 In general, some \emph{possible optimizations} are:
 
@@ -358,7 +361,7 @@ In general, some \emph{possible optimizations} are:
   \item  Avoid or limit branches in your code (A common branch is a check to see whether you're at the end of a loop);
   \item  To put the most likely branch upfront;
   \item  Apply code patterns to allow the CPU to make better branch prediction;
-  \item  Use special tags in your code to force the compiler to a certain prediction (e.g.: GCC has macros for encoding branch prediction information, where you can define ``likely'' and ``unlikely'' paths).
+  \item  Use special tags in your code to force the compiler to a certain prediction (e.g., GCC has macros for encoding branch prediction information, where you can define ``likely'' and ``unlikely'' paths).
 \end{enumerate}
 
 \subsection{Category \#6: Floating-Point Operations}
@@ -372,7 +375,7 @@ In general, some \emph{possible optimizations} are:
 
 \begin{enumerate}
   \item  to redesign the code and check if the number of ``sqrt'' and/or ``division'' calculations can be reduced (by using a pre-calculated value for instance);
-  \item  to explore specific arithmetic compiler options (e.g.: -ffast-math). ``-ffast-math'' allows the compiler to use faster hardware floating point instructions, at the potential expense of IEEE floating point compliance. If your program doesn't need strict compliance, this setting should theoretically net a boost in floating point performance for `\textit{free'}.
+  \item  to explore specific arithmetic compiler options (e.g., -ffast-math). ``-ffast-math'' allows the compiler to use faster hardware floating point instructions, at the potential expense of IEEE floating point compliance. If your program doesn't need strict compliance, this setting should theoretically net a boost in floating point performance for ``\textit{free}''.
   \item  To use \textit{invsqrt}: many modern platforms also offer inverse square root, which has the speed approximately the same as \textit{sqrt}, but is often more useful (e.g., by having \textit{invsqrt} you can compute both \textit{sqrt} and \textit{div} with one multiplication for each).
 \end{enumerate}
 

--- a/perfexpert/ch04_multi_core_multi_job.tex
+++ b/perfexpert/ch04_multi_core_multi_job.tex
@@ -1,8 +1,11 @@
 \chapter{Multi-core \& Multi-node Profiling}
-\label{ch:Multi_core_multi_node_profiling}
+\label{ch:ch04_multi_core_multi_node_profiling}
 
 \renewcommand{\exampledir}{examples/ch04-parallel}
-\strong{Tip: Find the source code for the examples in this Chapter in the directory:  ``\tilde/\exampledir''.}
+
+\begin{tip}
+Find the source code for the examples in this Chapter in the directory:  ``\tilde/\exampledir''.
+\end{tip}
 
 PerfExpert will read hardware performance counter events of the various cores and/or nodes that participated in the parallel computing. PerfExpert will generate a summary report, which is based on the performance of all components.
 
@@ -85,12 +88,12 @@ VUBrussel                   & \$ \textbf{module load openmpi/1.6.5/gcc/4.8.2}
 \end{prompt}
 
 The command line to run PerfExpert includes the MPI launcher script (i.e., mpirun). If we would start ``PerfExpert 0.1 mpirun mm\_mpi'', we would analyze the performance of the MPI launcher instead of the performance of your application. This is of course not what we want. You can use the ``\textit{-p}'' (prefix) command line argument of PerfExpert to define a prefix to the normal command line. In our case, we want to set the MPI launcher and all its arguments (e.g., -p
-"mpirun").
+``mpirun'').
 
 The command becomes:
 
 \begin{prompt}
-%\shellcmd{ perfexpert -p ``mpirun'' -c 0.1 ./mm\_mpi}%
+%\shellcmd{perfexpert -p ``mpirun'' -c 0.1 ./mm\_mpi}%
 [perfexpert] Collecting measurements [hpctoolkit]
 [perfexpert]    [1] 11.375589158 seconds (includes measurement overhead)
 [perfexpert]    [2] 11.637017437 seconds (includes measurement overhead)

--- a/perfexpert/ch05_more_perfexpert_functionality.tex
+++ b/perfexpert/ch05_more_perfexpert_functionality.tex
@@ -1,5 +1,5 @@
 \chapter{More PerfExpert Functionality}
-\label{ch:More_Perfexpert_Functionality}
+\label{ch:ch05_more_perfexpert_functionality}
 
 \section{Special Options}
 \label{sec:Special_Options}
@@ -7,7 +7,7 @@
 \subsection{Arguments}
 \label{subsec:Arguments}
 
-If your program takes any argument that starts with a "-'' signal, PerfExpert will interpret this as a command line option of its own. To help PerfExpert handle arguments and options correctly, use quotes and add a space before the program's arguments (e.g., " -s 50'').
+If your program takes any argument that starts with a ``-'' signal, PerfExpert will interpret this as a command line option of its own. To help PerfExpert handle arguments and options correctly, use quotes and add a space before the program's arguments (e.g., ``-s 50'').
 
 If your program would normally executed by the command:
 \begin{prompt}
@@ -21,7 +21,7 @@ the PerfExpert command line would become:
 \subsection{Input/Output pipes}
 \label{subsec:IO_Pipes}
 
-When your program reads from standard input via an input pipe (i.e.: ``$<$''), use the ``-i'' option. The Output pipe ('$>$') is not available because PerfExpert already sets a default output file.
+When your program reads from standard input via an input pipe (i.e., ``$<$''), use the ``-i'' option. The Output pipe ('$>$') is not available because PerfExpert already sets a default output file.
 
 If your program would normally executed by the command:
 \begin{prompt}
@@ -86,7 +86,7 @@ The automatic optimization is achieved by using one the 2 extra options:
 
 If you select the~-m~option and the application is composed of multiple files, your source code tree should have a Makefile file to enable PerfExpert compile your code. If your application is composed of a single source code file, the option~-s~is sufficient for you. If you do not select~-m~or~-s~options, PerfExpert requires only the binary code and will show you only the performance analysis report and the list of suggestion for bottleneck remediation.
 
-\strong{Caution:~} PerfExpert may, if you choose to use the full capabilities for automated optimization, change your source code during the process of optimization. PerfExpert always saves the original file with a different name (\textit{e.g.}, mm_omp.c.old\_27301) as well as adds annotations to your source code for each optimization it makes. We cannot, however, fully guarantee that code modifications for optimizations will not break your code. We recommend having a full backup of your original source code before using PerfExpert.
+\strong{Caution:~} PerfExpert may, if you choose to use the full capabilities for automated optimization, change your source code during the process of optimization. PerfExpert always saves the original file with a different name (e.g., mm_omp.c.old\_27301) as well as adds annotations to your source code for each optimization it makes. We cannot, however, fully guarantee that code modifications for optimizations will not break your code. We recommend having a full backup of your original source code before using PerfExpert.
 
 \subsection{Automatic Optimization of single source file}
 \label{subsec:Automatic_Optimization}
@@ -147,7 +147,7 @@ And run in automatic mode:
 \section{Running PerfExpert in Batch mode (with Job Script)}
 \label{sec:Batch_Mode}
 
-One can also run perfexpert in batch mode. This is often desired when the runtime of the program is a bit higher, and you do not want to wait for the results.  You can replace the normal command line to startup your executable (e.g.: ``./mm_omp'') in the jobscript with the perfexpert command line. (e.g.: ``\textit{perfexpert -c 0.3 mm_omp}''). When running your application with a jobscript, be sure to specify a running time that is about 6x the normal running time of the program.
+One can also run perfexpert in batch mode. This is often desired when the runtime of the program is a bit higher, and you do not want to wait for the results.  You can replace the normal command line to startup your executable (e.g., ``./mm_omp'') in the jobscript with the perfexpert command line. (e.g., ``\textit{perfexpert -c 0.3 mm_omp}''). When running your application with a jobscript, be sure to specify a running time that is about 6x the normal running time of the program.
 
 Compile the parallel Matrix Multiplication program, explore the job-script and submit the job:
 

--- a/perfexpert/ch07_optimization_patterns.tex
+++ b/perfexpert/ch07_optimization_patterns.tex
@@ -1,5 +1,5 @@
 \chapter{Annex 2: Optimization Patterns}
-\label{ch:Optimization_Patterns}
+\label{ch:ch07_optimization_patterns}
 
 \section{Memory Access optimizations}
 \label{sec:Memory_Access_Optimizations}
@@ -19,7 +19,7 @@ Category            & \multicolumn{2}{|p{4.0in}|}{Bad memory access} \\ \hline
 Description         & \multicolumn{2}{|p{4.0in}|}{Allocate an array of elements instead of each element individually} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & loop \{\newline   \ldots c = malloc(1); \ldots\newline \}\newline
-                    & top = n;\newline loop \{\newline   if (top == n) \{\newline     tmp = malloc(n);\newline     top = 0;\newline   \}\newline   \ldots\newline   c = \&tmp[top++]; \ldots\newline \}" \\ \hline
+                    & top = n;\newline loop \{\newline   if (top == n) \{\newline     tmp = malloc(n);\newline     top = 0;\newline   \}\newline   \ldots\newline   c = \&tmp[top++]; \ldots\newline \} \\ \hline
 \end{tabular}
 
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
@@ -28,7 +28,7 @@ Category            & \multicolumn{2}{|p{4.0in}|}{Bad memory access} \\ \hline
 Description         & \multicolumn{2}{|p{4.0in}|}{Apply loop fission so every loop accesses just a couple of different arrays} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & loop i \{\newline   a[i] = a[i] * b[i] - c[i];\newline \}
-                    & loop i \{\newline   a[i] = a[i] * b[i];\newline \}\newline loop i \{\newline   a[i] = a[i] - c[i];\newline \}" \\ \hline
+                    & loop i \{\newline   a[i] = a[i] * b[i];\newline \}\newline loop i \{\newline   a[i] = a[i] - c[i];\newline \} \\ \hline
 \end{tabular}
 
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
@@ -42,7 +42,7 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R005}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Change the order of loops}} \\ \hline
-Category            & \multicolumn{2}{|p{4.0in}|}{Bad memory access\newline Bad data TLB access } \\ \hline
+Category            & \multicolumn{2}{|p{4.0in}|}{Bad memory access\newline Bad data TLB access} \\ \hline
 Description         & \multicolumn{2}{|p{4.0in}|}{Change the order of loops} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & loop i \{\newline   loop j \{\ldots\}\newline \}
@@ -106,7 +106,7 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R012}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Smaller types}} \\ \hline
 Category            & \multicolumn{2}{|p{4.0in}|}{Bad memory access\newline Bad data TLB access} \\ \hline
-Description         & \multicolumn{2}{|p{4.0in}|}{Use smaller types (e.g., float instead of double or short instead of int) } \\ \hline
+Description         & \multicolumn{2}{|p{4.0in}|}{Use smaller types (e.g., float instead of double or short instead of int)} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & double a[n]; & float a[n]; \\ \hline
 \end{tabular}
@@ -149,7 +149,7 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R017}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Restrict}} \\ \hline
 Category            & \multicolumn{2}{|p{4.0in}|}{Bad L1 data access} \\ \hline
-Description         & \multicolumn{2}{|p{4.0in}|}{Help the compiler by marking pointers to non-overlapping data with "restrict"} \\ \hline
+Description         & \multicolumn{2}{|p{4.0in}|}{Help the compiler by marking pointers to non-overlapping data with ``restrict''} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & void *a, *b; & void * restrict a, * restrict b; \\ \hline
 \end{tabular}
@@ -160,7 +160,7 @@ Category            & \multicolumn{2}{|p{4.0in}|}{Bad L1 data access} \\ \hline
 Description         & \multicolumn{2}{|p{4.0in}|}{Move loop invariant memory accesses out of loop} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & loop i \{\newline   a[i] = b[i] * c[j]\newline\}
-                    & temp = c[j];\newline loop i \{\newline   a[i] = b[i] * temp;\newline \}" \\ \hline
+                    & temp = c[j];\newline loop i \{\newline   a[i] = b[i] * temp;\newline \} \\ \hline
 \end{tabular}
 
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
@@ -177,12 +177,12 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 Category            & \multicolumn{2}{|p{4.0in}|}{Bad L1 data access\newline Bad float point instructions (slow FP)} \\ \hline
 Description         & \multicolumn{2}{|p{4.0in}|}{Use float instead of double data type if loss of precision is acceptable.} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
-                    & double a[n]; & float a[n];" \\ \hline
+                    & double a[n]; & float a[n]; \\ \hline
 \end{tabular}
 
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R021}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Compute iso loading}} \\ \hline
-Category            & \multicolumn{2}{|p{4.0in}|}{Bad L2 data access\newline Bad memory access } \\ \hline
+Category            & \multicolumn{2}{|p{4.0in}|}{Bad L2 data access\newline Bad memory access} \\ \hline
 Description         & \multicolumn{2}{|p{4.0in}|}{Compute values rather than loading them if doable with few operations} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & loop i \{\newline   t[i] = a[i] * 0.5;\newline \}\newline loop i \{\newline   a[i] = c[i] - t[i];\newline \}
@@ -198,16 +198,16 @@ Category            & \multicolumn{2}{|p{4.0in}|}{Bad instruction access} \\ \hl
 Description         & \multicolumn{2}{|p{4.0in}|}{Factor out sequences of common code into subroutines} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & same\_code;\newline same\_code;
-                    & void f() \{same\_code;\}\newline f();\newline f();" \\ \hline
+                    & void f() \{same\_code;\}\newline f();\newline f(); \\ \hline
 \end{tabular}
 
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R101}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Lower loop unroll factor}} \\ \hline
 Category            & \multicolumn{2}{|p{4.0in}|}{Bad instruction access} \\ \hline
-Description         & \multicolumn{2}{|p{4.0in}|}{Lower the loop unroll factor } \\ \hline
+Description         & \multicolumn{2}{|p{4.0in}|}{Lower the loop unroll factor} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & loop i step 4 \{\newline   code\_i;\newline   code\_i+1;\newline   code\_i+2;\newline   code\_i+3;\newline \}
-                    & loop i step 2 \{\newline   code\_i;\newline   code\_i+1;\newline \}" \\ \hline
+                    & loop i step 2 \{\newline   code\_i;\newline   code\_i+1;\newline \} \\ \hline
 \end{tabular}
 
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
@@ -221,7 +221,7 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R103}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Sort according call chains}} \\ \hline
-Category            & \multicolumn{2}{|p{4.0in}|}{Bad instruction access\newline Bad instruction TLB access } \\ \hline
+Category            & \multicolumn{2}{|p{4.0in}|}{Bad instruction access\newline Bad instruction TLB access} \\ \hline
 Description         & \multicolumn{2}{|p{4.0in}|}{Sort subroutines by call chains (subroutine coloring)} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & f() \{\ldots\}\newline g() \{\ldots\}\newline h() \{\ldots\}\newline loop \{\newline   f();\newline   h();\newline \}
@@ -231,10 +231,10 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R104}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Split off cold code}} \\ \hline
 Category            & \multicolumn{2}{|p{4.0in}|}{Bad instruction access} \\ \hline
-Description         & \multicolumn{2}{|p{4.0in}|}{Split off cold code into separate subroutines and place them at end of file } \\ \hline
+Description         & \multicolumn{2}{|p{4.0in}|}{Split off cold code into separate subroutines and place them at end of file} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & if (unlikely\_condition) \{\newline   lots\_of\_code\newline \}
-                    & void f() \{lots\_of\_code\}\newline \ldots\newline if (unlikely\_condition)\newline   f();" \\ \hline
+                    & void f() \{lots\_of\_code\}\newline \ldots\newline if (unlikely\_condition)\newline   f(); \\ \hline
 \end{tabular}
 
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
@@ -258,10 +258,10 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R107}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Inlining}} \\ \hline
 Category            & \multicolumn{2}{|p{4.0in}|}{Bad instruction TLB access} \\ \hline
-Description         & \multicolumn{2}{|p{4.0in}|}{Use inlining } \\ \hline
+Description         & \multicolumn{2}{|p{4.0in}|}{Use inlining} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & float f(float x) \{\newline   return x * x;\newline \}\newline z = f(y);
-                    & z = y * y;" \\ \hline
+                    & z = y * y; \\ \hline
 \end{tabular}
 
 \section{Branches optimizations}
@@ -297,7 +297,7 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R203}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Remove IF}} \\ \hline
 Category            & \multicolumn{2}{|p{4.0in}|}{Bad branch instructions} \\ \hline
-Description         & \multicolumn{2}{|p{4.0in}|}{Remove IF } \\ \hline
+Description         & \multicolumn{2}{|p{4.0in}|}{Remove IF} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & /* x is 0 or -1 */\newline if (x == 0)\newline   a = b;\newline else\newline   a = c;
                     & a = (b \& ~x) \textbar  (c \& x); \\ \hline
@@ -324,7 +324,7 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R206}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Conditional moves}} \\ \hline
 Category            & \multicolumn{2}{|p{4.0in}|}{Bad branch instructions} \\ \hline
-Description         & \multicolumn{2}{|p{4.0in}|}{Use trivial assignments inside THEN/ELSE to allow the use of conditional moves } \\ \hline
+Description         & \multicolumn{2}{|p{4.0in}|}{Use trivial assignments inside THEN/ELSE to allow the use of conditional moves} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & if (x $<$ y)\newline   a = x + y;
                     & temp = x + y;\newline if (x $<$ y)\newline   a = temp;  \\ \hline
@@ -372,7 +372,7 @@ Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
 \begin{tabular}{|p{0.9in}|p{2.0in}|p{2.0in}|} \hline
 \textbf{R304}       & \multicolumn{2}{|p{4.0in}|}{\textbf{Rework SQRT in conditions}} \\ \hline
 Category            & \multicolumn{2}{|p{4.0in}|}{Bad float point instructions (slow FP)} \\ \hline
-Description         & \multicolumn{2}{|p{4.0in}|}{Compare squared values instead of computing the square root } \\ \hline
+Description         & \multicolumn{2}{|p{4.0in}|}{Compare squared values instead of computing the square root} \\ \hline
 Code Sample         & \textbf{Old} & \textbf{New} \\ \hline
                     & if (x $<$ sqrt(y))\newline \{\ldots\}
                     & if ((x $<$ 0.0) \textbar \textbar  (x*x $<$ y))\newline \{\ldots\} \\ \hline

--- a/perfexpert/glossary.tex
+++ b/perfexpert/glossary.tex
@@ -21,7 +21,7 @@
 \newglossaryentry{Distributed-memory-system}
 {
   name={Distributed memory system},
-  description={Computing system consisting of many compute nodes connected by a network, each with their own memory. Accessing memory on a neighboring node is possible but require explicit communication },
+  description={Computing system consisting of many compute nodes connected by a network, each with their own memory. Accessing memory on a neighboring node is possible but require explicit communication},
 }
 \newglossaryentry{Flop}
 {
@@ -71,7 +71,7 @@
 \newglossaryentry{Modules}
 {
   name={Modules},
-  description={UA-HPC uses an open source software package called "Environment Modules," (Modules for short) which allows you to add various path definitions to your shell environment},
+  description={UA-HPC uses an open source software package called ``Environment Modules'', (Modules for short) which allows you to add various path definitions to your shell environment},
 }
 \newglossaryentry{MPI}
 {
@@ -96,7 +96,7 @@
 \newglossaryentry{Shared-memory-system}
 {
   name={Shared memory system},
-  description={Computing system in which all of the processors share one global memory space. However, access times from a processor to different regions of memory are not necessarily uniform },
+  description={Computing system in which all of the processors share one global memory space. However, access times from a processor to different regions of memory are not necessarily uniform},
 }
 \newglossaryentry{SSH}
 {
@@ -121,7 +121,7 @@
 \newglossaryentry{TLB}
 {
   name={TLB},
-  description={Translation\textbf{\textit{ }}Look-aside Buffer\textit{,} a table in the processor's memory that contains information about the virtual memory pages the processor has accessed recently. The table cross-references a program's virtual addresses with the corresponding absolute addresses in physical memory that the program has most recently used. The TLB enables faster computing because it allows the address processing to take place independent of the normal address-translation pipeline.},
+  description={Translation Look-aside Buffer, a table in the processor's memory that contains information about the virtual memory pages the processor has accessed recently. The table cross-references a program's virtual addresses with the corresponding absolute addresses in physical memory that the program has most recently used. The TLB enables faster computing because it allows the address processing to take place independent of the normal address-translation pipeline.},
 }
 \newglossaryentry{TACC}
 {

--- a/perfexpert/perfexpert.tex
+++ b/perfexpert/perfexpert.tex
@@ -29,11 +29,11 @@
 
 \emph{The First Rule of Program Optimization: Don't do it.}
 
-\emph{The Second Rule of Program Optimization (for experts only!): Don't do it yet."}
+\emph{The Second Rule of Program Optimization (for experts only!): Don't do it yet.}
 
   ---  Michael A. Jackson ---
 
-\emph{The Third Rule of Program Optimization: Let the computer do it for you."}
+\emph{The Third Rule of Program Optimization: Let the computer do it for you.}
 
 --- The PerfExpert Team ---
 

--- a/perfexpert/title.tex
+++ b/perfexpert/title.tex
@@ -26,7 +26,7 @@ Geert Borstlap
 
 \vspace*{.5\baselineskip}
 
-\strong{Written/contributions by: }
+\strong{Written/contributions by:}
 
 James C.\ Browne, Leonardo Fialho
 
@@ -46,7 +46,7 @@ Acknowledgement: TACC-staff, Susan H.\ Mehringer
 
 \strong{Audience:}
 
-This PerfExpert Tutorial is designed for \strong{HPC-Users} at the \strong{University of Texas}, the members of the\strong{ Flemish Supercomputing Center (VSC)}, being the \strong{University of Antwerp}, the \strong{University of Gent}, The \strong{Catholic University of Leuven}, the \strong{University of Brussels} and the \strong{University of Hasselt} and affiliated institutes who want to profile and optimize their applications.
+This PerfExpert Tutorial is designed for \strong{HPC-Users} at the \strong{University of Texas}, the members of the \strong{Flemish Supercomputing Center (VSC)}, being the \strong{University of Antwerp}, the \strong{University of Gent}, The \strong{Catholic University of Leuven}, the \strong{University of Brussels} and the \strong{University of Hasselt} and affiliated institutes who want to profile and optimize their applications.
 
 The audience may be completely unaware of the profiling and optimization concepts but must have some basic understanding of HPC programming.
 
@@ -54,21 +54,21 @@ The audience may be completely unaware of the profiling and optimization concept
 
 This tutorial gives answers to the typical questions that a new PerfExpert user may have. The aim is to learn how to use PerfExpert.
 
-\begin{tabular}{|c|l|c|l} \hline
+\begin{tabular}{|c|p{0.3\textwidth}|c|p{0.4\textwidth}|} \hline
 \strong{Part} & \strong{Questions}                          & \strong{Chapter}  & \strong{Title}    \\ \hline
-Tutorial      & What's perfExpert?                          & \strong{1}        & Introduction      \\ \hline
-              & How to profile and interpret the report?    & \strong{2}        & Profiling         \\ \hline
-              & How shall I optimize my code?               & \strong{3}        & Optimization      \\ \hline
-              & But what about my complex parallel program? & \strong{4}        & Multi-core and Multi Node Profiling \\ \hline
-              & What can I do more?                         & \strong{5}        & Extra PerfExpert functionality \\ \hline
+Tutorial      & What's PerfExpert?                          & \strong{\ref{ch:ch01_introduction}}        & \nameref{ch:ch01_introduction}      \\ \hline
+              & How to profile and interpret the report?    & \strong{\ref{ch:ch02_profiling}}        & \nameref{ch:ch02_profiling} \\ \hline
+              & How shall I optimize my code?               & \strong{\ref{ch:ch03_optimizing}}        & \nameref{ch:ch03_optimizing} \\ \hline
+              & But what about my complex parallel program? & \strong{\ref{ch:ch04_multi_core_multi_node_profiling}}        & \nameref{ch:ch04_multi_core_multi_node_profiling} \\ \hline
+              & What can I do more?                         & \strong{\ref{ch:ch05_more_perfexpert_functionality}}        & \nameref{ch:ch05_more_perfexpert_functionality} \\ \hline
 \end{tabular}
 
 The \strong{Annexes} contains some useful reference guides.
 
 \begin{tabular}{|c|l|c|} \hline
 \strong{Part}   & \strong{Title}        & \strong{Chapter}  \\ \hline
-Annex           & PerfExpert Options    & \strong{6}        \\ \hline
-                & Optimization patterns & \strong{7}        \\ \hline
+Annex           & \nameref{ch:ch06_perfexpert_options}  & \strong{\ref{ch:ch06_perfexpert_options}}        \\ \hline
+                & \nameref{ch:ch07_optimization_patterns}  & \strong{\ref{ch:ch07_optimization_patterns}}        \\ \hline
 \end{tabular}
 
 \strong{Notification:}
@@ -79,15 +79,19 @@ In this tutorial specific actions dealing with the software are separated from t
 %\shellcmd{Actions}% (i.e., to be entered at a command line in your Terminal) in an exercise are preceded by a $ and printed in \strong{bold}. You'll find those actions in a grey frame.
 \end{prompt}
 
-\strong{`Directory'} is the notation for directories or specific files. (e.g., `~/examples/')
+\strong{``Directory''} is the notation for directories or specific files. (e.g., ``~/examples/'')
 \strong{``Text''} Is the notation for text to be entered.
-\strong{Tip:} A ``Tip'' paragraph is used for remarks or tips.
+
+\begin{tip}
+A ``Tip'' paragraph is used for remarks or tips.
+\end{tip}
+
 \strong{More support:} \\
 
 Before starting the course, the example programs and configuration files used in this PerfExpert Tutorial must be copied to your own work directory.
 
 \iftacc
-The examples can also be downloaded from \url{https://portal.tacc.utexas.edu/user-services/training/} or copied from the training directory  `\emph{\tutorialdir/perfexpert/examples}' on Stampede to your home directory.
+The examples can also be downloaded from \url{https://portal.tacc.utexas.edu/user-services/training/} or copied from the training directory  ``\emph{\tutorialdir/perfexpert/examples}'' on Stampede to your home directory.
 \fi
 \ifvsc
 If you have received a new VSC account, all examples are present in the tutorials directory. In order to have your own local copy, copy the full directory to your home directory.
@@ -99,7 +103,10 @@ If you have received a new VSC account, all examples are present in the tutorial
 
 Apart from this Tutorial, the PerfExpert documentation on Texas Advanced Computing Center (TACC) website (\url{https://www.tacc.utexas.edu/perfexpert}) will serve as a reference for all PerfExpert operations.
 
-\strong{Tip:} The users are advised to get self-organized. There are only limited resources available at the TACC, which are best effort based. The user applications and own developed software remain solely the responsibility of the end-user.
+\begin{tip}
+The users are advised to get self-organized. There are only limited resources available at the TACC, which are best effort based. The user applications and own developed software remain solely the responsibility of the end-user.
+\end{tip}
+
 
 \strong{Contact Information:}
 

--- a/style-guide.tex
+++ b/style-guide.tex
@@ -76,11 +76,11 @@ To display example code inside the document you can use the \verb|\examplecode|
 command. The example code files should be organised in an \verb|examples|
 subdirectory.  Each chapter should have its own directory. The directory name
 is the same as the chapter name with spaces and slashes substituted by dashes.
-(e.g. ``Multi-core Job Submission'' is turned into
+(e.g., ``Multi-core Job Submission'' is turned into
 ``Multi-core-Job-Submission'').
 
 The \verb|examplecode| takes 2 mandatory arguments. The first one is the
-language of the code file (e.g. C or Python). The second is the basename of the
+language of the code file (e.g., C or Python). The second is the basename of the
 file. If you want you can organize the example files per chapter in
 subdirectories, you then need to add the subdirectory to the filename argument.
 The commands below illustrate how this works.
@@ -104,7 +104,7 @@ includes a \$-sign. There is a special version of this command called
 it writes its argument to \verb|shellcmds.sh|. All commands you want to capture
 will be present here. This file will be updated each time you build the pdf.
 You can use this to easily run commands and paste their output in the latex
-file. NOTE: instead of \verb|\tilde| you should use a regular \tilde inside
+file. NOTE: instead of \verb|\tilde| you should use a regular \tilde{} inside
 \verb|\shellcmd| and \verb|\captureshellcmd|. Inside the prompt environment you
 can use \% as escape character to type commands.
 
@@ -156,8 +156,8 @@ echo "test"
 \section{Windows and Mac-specific}
 \label{sec:windows-and-mac-specific}
 
-You can write Windows or Mac specific sections with the \texttt{ifmac} and
-\texttt{ifwindows} commands.
+You can write Windows, Mac or Linux specific sections with the \texttt{ifwindows}, \texttt{ifmac}, \texttt{iflinux} and
+\texttt{ifmacORlinux} commands.
 
 \begin{verbatim}
 \ifwindows
@@ -194,7 +194,7 @@ Note: this command will not fail if the site-specific section is missing.
 \includesite{intro}
 \end{verbatim}
 
-The above example will not include intro.tex, but will include <site>/intro.tex (e.g. gent/intro.tex)
+The above example will not include intro.tex, but will include <site>/intro.tex (e.g., gent/intro.tex)
 
 Because includes cannot be nested there is also the \verb|\inputsite| command
 which works exactly the same as above only it uses \verb|\input| instead of

--- a/style.tex
+++ b/style.tex
@@ -18,6 +18,8 @@
 \usepackage{xstring}
 \usepackage{verbatim}
 \usepackage{courier}
+\usepackage{xparse}
+\usepackage{menukeys}
 \renewcommand{\ttdefault}{pcr}
 
 \setlength{\hoffset}{-1in}
@@ -140,6 +142,17 @@
   \StrSubstitute{#1}{ }{-}[\x]
   \StrSubstitute{\x}{/}{-}[\Chaptername]
   \Chaptermark{#1}}
+
+
+\ExplSyntaxOn
+    \NewDocumentEnvironment{tip} { o }
+     {
+      \par\noindent
+      \IfNoValueTF{#1} { \textbf{Tip:~} }{ \textbf{Tip:~#1:~} }
+       \ignorespaces
+     }
+     {}
+\ExplSyntaxOff
 
 
 \parindent=0pt


### PR DESCRIPTION
- e.g., i.e., ...: always followed by comma
- consistent use of capitals: TORQUE, Moab, PBS, Perl, Python, Fortran, MATLAB, Intel, ...
- consistent use of I/O, MB, GB, kB, ...
- replaced " by `` ''
- replaced single quotes (both `and ') by`` ''
- removed spaces before punctuation
- added space after punctuation
- removed $ from \footnote
- replaced 's by s (plural)
- replaced commando by command
- removed space before },) and after {,(
- added space before {,( and after },)
- introduced menukeys package and \keys and \menu macros
- introduced tip environment
- introduced \ref, \nameref and \autoref
- first update of UA related items
