### PR TITLE
typos Oct 2015 (perfexpert)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ defines = ""
 
 all_os = linux mac windows
 all_site = antwerpen brussel gent leuven
-all_doc = intro-HPC perfexpert
+all_doc_os = intro-HPC
+all_doc_noos = perfexpert
 
 
 # http://stackoverflow.com/questions/18136918/how-to-get-current-directory-of-your-makefile
@@ -13,14 +14,16 @@ ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 default:
 ifdef OS
-	make all
+	make all_os all_noos
 else ifdef SITE
-	make all
-else ifdef DOC
-	make all
+	make all_os all_noos
+else ifneq (,$(findstring $(DOC),$(all_doc_noos)))
+	make all_noos
+else ifneq (,$(findstring $(DOC),$(all_doc_os)))
+	make all_os
 else
 	@echo "One or more of the following variables must be set, unless 'make all' is used to build everything:"
-	@echo "    DOC: $(all_doc)"
+	@echo "    DOC: $(all_doc_os) $(all_doc_noos)"
 	@echo "    OS: $(all_os)"
 	@echo "    SITE: $(all_site)"
 	@echo "Example: 'make OS=windows SITE=gent'"
@@ -34,12 +37,18 @@ ifndef SITE
 SITE=$(all_site)
 endif
 ifndef DOC
-DOC=$(all_doc)
+DOCOS=$(all_doc_os)
+DOCNOOS=$(all_doc_noos)
+else
+DOCOS=$(DOC)
+DOCNOOS=$(DOC)
 endif
 
-all:
+all: all_os all_noos
+
+all_os:
 	@for os in $(OS) ; do \
-		for doc in $(DOC) ; do \
+		for doc in $(DOCOS) ; do \
 			cd $(ROOT_DIR)/$$doc ; \
 			for site in $(SITE) ; do \
 				jobname="$$doc-$$os-$$site" ; \
@@ -47,10 +56,25 @@ all:
 				$$latexcommand | grep -C 15 'Fatal error' && echo "$$jobname" failed, see log in $$doc/$$jobname.log && continue ; \
 				makeglossaries $$jobname > /dev/null 2>&1 ; \
 				$$latexcommand | grep -C 15 'Fatal error' && echo "$$jobname" failed, see log in $$doc/$$jobname.log && continue ; \
+				$$latexcommand | grep -C 15 'Fatal error' && echo "$$jobname" failed, see log in $$doc/$$jobname.log && continue ; \
 				echo ./$$doc/$$jobname.pdf created ; \
 			done ; \
 		done ; \
 	done ;
+
+all_noos:
+	@for doc in $(DOCNOOS) ; do \
+		cd $(ROOT_DIR)/$$doc ; \
+		for site in $(SITE) ; do \
+			jobname="$$doc-$$site" ; \
+			latexcommand="pdflatex -interaction nonstopmode -jobname $$jobname \"\def\is$$os{1}\def\is$$site{1}\input{$$doc.tex}\" " ; \
+			$$latexcommand | grep -C 15 'Fatal error' && echo "$$jobname" failed, see log in $$doc/$$jobname.log && continue ; \
+			makeglossaries $$jobname > /dev/null 2>&1 ; \
+			$$latexcommand | grep -C 15 'Fatal error' && echo "$$jobname" failed, see log in $$doc/$$jobname.log && continue ; \
+			$$latexcommand | grep -C 15 'Fatal error' && echo "$$jobname" failed, see log in $$doc/$$jobname.log && continue ; \
+			echo ./$$doc/$$jobname.pdf created ; \
+		done ; \
+	done ; \
 
 style-guide: style-guide.pdf
 
@@ -59,7 +83,7 @@ style-guide.pdf: style-guide.tex macros.tex
 	pdflatex style-guide.tex
 
 clean:
-	@for doc in $(all_doc) ; do \
+	@for doc in $(all_doc_os) $(all_doc_noos) ; do \
 		cd $(ROOT_DIR)/$$doc ; \
 		rm -f *.log *.aux *.fdb_latexmk *.listing *.fls *.toc *.out *.glg *.glo *.gls *.ist *.ind *.ilg *.idx ; \
 	done ;

--- a/perfexpert/antwerpen/contact-information.tex
+++ b/perfexpert/antwerpen/contact-information.tex
@@ -1,13 +1,17 @@
 \begin{enumerate}
 \item  By e-mail:  \hpcinfo
-\item  By Phone : 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert)
-\item  In real  : Campus Middelheim, Building G, Room G.309 and G.310
+\item  By phone: 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert), 03/2653852 (Kurt)
+\item  In real: Campus Middelheim, Building G, Room G.309 and G.310
 \end{enumerate}
 
 Mailing-lists:
 
 \begin{enumerate}
 \item  Announcements: \hpcannounceml (for official announcements and communications)
-\item  Users : \hpcusersml (for discussions between users)
+\item  Users: \hpcusersml (for discussions between users)
 \end{enumerate}
 
+New users are automatically added to both mailing lists.
+You can check the archives on \url{https://sympa.ua.ac.be/sympa/}, but you will need to
+generate a password first on that site using your main e-mail address (on which you
+receive the mailing list).

--- a/perfexpert/ch01_introduction.tex
+++ b/perfexpert/ch01_introduction.tex
@@ -46,9 +46,15 @@ You can now create your own copy of the examples by copying the examples for thi
 
 The runs with PerfExpert should be made using a data set size for each compute node which is representative to a full production runs but for which execution time is not more than about ten or fifteen minutes since PerfExpert will run your application multiple times (actually, three times on Stampede) with different performance counters enabled.
 
-For that reason, before you run PerfExpert for your own purpose later, you should either request interactive access to computational resources (compute node), or modify the job script that you use to run your application and specify a running time that is about 3 (for Stampede, Hopper) or 6 (for Lonestar) times the normal running time of the program.
+For that reason, before you run PerfExpert for your own purpose later, you should either request interactive access to computational resources (compute node), or modify the job script that you use to run your application and specify a running time that is about 
+\iftacc 
+  3 (for Stampede) or 6 (for Lonestar)
+\else
+  3 (for \hpcname)
+\fi
+ times the normal running time of the program.
 
-For the exercises in this tutorial, we request interactive access on a compute node to work on for e.g., 2 hours:
+For the exercises in this tutorial, we request interactive access on a compute node to work on for, e.g., 2 hours:
 
 \iftacc
 \begin{prompt}

--- a/perfexpert/ch02_profiling.tex
+++ b/perfexpert/ch02_profiling.tex
@@ -55,11 +55,10 @@ Remember to load the appropriate PerfExpert modules:
 \end{prompt}
 \fi
 
-For our first example, we'll use a simple serial 1000x1000 matrix multiplication program. Check out the program ``mm.c'', compile and run it.
+For our first example, we'll use a simple serial 1000 $\times$ 1000 matrix multiplication program. Check out the program ``mm.c'', compile and run it.
 
 \begin{prompt}
 %\shellcmd{cat mm.c}%
-%\...%
 %\shellcmd{gcc -o mm mm.c}%
 %\shellcmd{./mm}%
 \end{prompt}
@@ -75,7 +74,7 @@ sys 0m0.010s
 
 Just adding ``perfexpert'' in front of your normal command line will activate the PerfExpert profiler.  It will start the PerfExpert profiling tool, which will run the executable multiple times and collect the performance metrics.
 
-We also have to define a threshold, which defines the relevance (in \% of runtime) of the code fragments that PerfExpert should investigate. We want to focus our performance checks to those code segments, which consume the majority of the computer resources.  This threshold value should be between 0 and 1. (> 0 and $<$= 1).  A threshold of 0.3 means that PerfExpert will only focus on those functions, which are responsible for more than 30\% of the runtime.
+We also have to define a threshold, which defines the relevance (in \% of runtime) of the code fragments that PerfExpert should investigate. We want to focus our performance checks to those code segments, which consume the majority of the computer resources.  This threshold value should be between 0 and 1. (> 0 and $\leq 1$).  A threshold of 0.3 means that PerfExpert will only focus on those functions, which are responsible for more than 30\% of the runtime.
 
 \begin{prompt}
 %\shellcmd{perfexpert 0.3 ./mm}%
@@ -119,7 +118,7 @@ performance assessment LCPI good..........okay..........fair........... poor....
 - fast FP instr        1.63 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 ==========================================================================
 [perfexpert] Selecting optimizations
-\...
+...
 \end{prompt}
 
 You notice that:
@@ -127,7 +126,7 @@ You notice that:
 \begin{enumerate}
   \item  PerfExpert used the HPCToolkit to collect the performance measurements. It is using statistical sampling of timers and hardware performance counters to collect accurate measurements of the program.
   \item  The matrix multiplication program ran 3 times.
-  \item  Each run took 8 to 9 seconds to complete. The average execution time was 8.66 second, which is a bit more as the execution time without profiling. It shows that profiling causes some extra execution overheads.
+  \item  Each run took 8 to 9 seconds to complete. The average execution time was 8.66 seconds, which is a bit more as the execution time without profiling. It shows that profiling causes some extra execution overheads.
   \item  One function was detected in the program that took more than 30\% of the total execution time. The ``compute'' function in an ``~unknown file~'' used 99.96\% of the runtime.
   \item  A detailed analysis of the ``compute'' function was presented. We'll discuss this in depth in the next chapter.
   \item  Three recommendations to improve the speed of the ``compute'' function were suggested.
@@ -140,7 +139,7 @@ Always compile your programs with the debug option (-g) on.
 \end{tip}
 
 \begin{tip}
-If you using gcc 4.8 or newer, you should use -gdwarf-3 option!
+If you are using gcc 4.8 or newer, you should use -gdwarf-3 option!
 \end{tip}
 
 
@@ -206,7 +205,7 @@ In the previous Matrix-Multiplication example, our GFLOP values were:
 
 The higher the GFLOPS percentage, the more efficient are computations are done. Although it is rare for real-world programs to match even 50\% of the maximum value, this metric can serve as an estimate of how efficiently the code performs computations.
 
-This performance report gives us also an indication about the ``vectorisation degree'', i.e., the percentage of the computations that were ``vectorised'' (=packed) and run in parallel.
+This performance report gives us also an indication about the ``vectorisation degree'', i.e., the percentage of the computations that were ``vectorised'' ($=$ packed) and run in parallel.
 
 \begin{prompt}
 * GFLOPS (%\%% max)        12.5 ******
@@ -219,7 +218,7 @@ This performance report gives us also an indication about the ``vectorisation de
   \item  \emph{Scalar}: This represents the \% of FP instructions which were not vectorised. These computations were executed one by one in serial mode and the value should be low.
 \end{enumerate}
 
-You noticed that the Matrix Multiplication program was not able to \emph{`vectorise'} (Packed was 0\%) and that all our FP computations were executed sequentially (Scalar was 12.5\%).
+You noticed that the Matrix Multiplication program was not able to ``\emph{vectorise}'' (Packed was 0\%) and that all our FP computations were executed sequentially (Scalar was 12.5\%).
 
 \section{Profiling the LCPI Performance Categories}
 \label{sec:Profiling_the_LCPI_Performance_Categories}
@@ -271,7 +270,7 @@ High LCPI values in this category generally indicate poor memory access patterns
   - LLC misses           0.00
 \end{prompt}
 
-We will start from the previous matrix multiplication program and generate a program with inefficient data-access. Instead of looping correctly through the matrices (``row from matrix a'' x ``column from matrix b''), we will now access both matrices ``a'' and ``b'' in a vertical manner (column by column). \emph{We do of course not aim to perform a correct matrix-multiplication}, as we are not interested in the results. We just want to show the effect of accessing data in a scattered (non-linear) way and causing \emph{non-optimal data access locality}.
+We will start from the previous matrix multiplication program and generate a program with inefficient data-access. Instead of looping correctly through the matrices (``row from matrix a'' $\times$ ``column from matrix b''), we will now access both matrices ``a'' and ``b'' in a vertical manner (column by column). \emph{We do of course not aim to perform a correct matrix-multiplication}, as we are not interested in the results. We just want to show the effect of accessing data in a scattered (non-linear) way and causing \emph{non-optimal data access locality}.
 
 Explore the test1.c program.
 
@@ -397,7 +396,7 @@ for (j = 0; j $<$ MAX_J; j++)
 
 And compile and run PerfExpert.
 
-We do not want to see the recommendations yet, so we add the ``-r0'' option.  (r0=give me zero recommendations)
+We do not want to see the recommendations yet, so we add the ``-r0'' option.  (r0 $=$ give me zero recommendations)
 
 \begin{prompt}
 %\shellcmd{gcc -g -o test3 test3.c}%
@@ -553,19 +552,19 @@ We notice that:
 
 The time that is wasted in the case of a branch misprediction is equal to the number of stages in the pipeline from the fetch stage to the execute stage. Modern microprocessors tend to have quite long pipelines so that the misprediction delay is between 10 and 20 clock cycles. The longer the pipeline the greater the need for a good branch prediction.
 
-In order to compare the effect of the branch predictor when it is able to provide good predictions, we also prepared a similar program (i.e., test5b.c), but now with completely predictable branches. We alternatively put the values 0, 1, 2 and 3 (= i\%4) in the array.
+In order to compare the effect of the branch predictor when it is able to provide good predictions, we also prepared a similar program (i.e., test5b.c), but now with completely predictable branches. We alternatively put the values 0, 1, 2 and 3 ($=$ i\%4) in the array.
 
 Explore, compile, run the example and check the results, paying particular attention to the overall execution time and the mispredicted branches.
 
 \begin{prompt}
 %\shellcmd{cat test5b.c}%
-\...
+...
  for(i = 0; i $<$ ARRAY\_LEN; ++i)
    a[i] = i PERCENTAGE-SIGN 4;
-\...
+...
 %\shellcmd{gcc -g -o test5b test5b.c}%
 %\shellcmd{perfexpert --c 0.3 ./test5b}%
-\...
+...
 [perfexpert] Collecting measurements [hpctoolkit]
 [perfexpert]    [1] 6.687911876 seconds (includes measurement overhead)
 [perfexpert]    [2] 6.677188251 seconds (includes measurement overhead)
@@ -574,7 +573,7 @@ Explore, compile, run the example and check the results, paying particular atten
 * branch instructions   0.17 >>>
  - correctly predicted  0.17 >>>
  - mispredicted         0.00
-\...
+...
 \end{prompt}
 
 The branch predictor in the processor has detected the pattern and is now able to completely predict the branches, which has its effect on the execution time of the program.
@@ -665,5 +664,5 @@ We notice in this example that:
 
 This \emph{analysis} indicates a \emph{performance} issue related to the \emph{slow floating-point calculations}. Just the square root operations (calls to libm) are responsible for 28\% of the runtime, so an improvement might heavily impact to total runtime.
 
-As a general rule of thumb: Both floating-point division and square root are considered as slow operations. Addition, subtraction and multiplication are fast FP operations. Square root can be expect to be approximately the same speed or somewhat slower (i.e., approx. 1x - 2x lower performance) compared to a division.
+As a general rule of thumb: Both floating-point division and square root are considered as slow operations. Addition, subtraction and multiplication are fast FP operations. Square root can be expect to be approximately the same speed or somewhat slower (i.e., approx. 1$\times$ - 2$\times$ lower performance) compared to a division.
 

--- a/perfexpert/ch03_optimizing.tex
+++ b/perfexpert/ch03_optimizing.tex
@@ -41,7 +41,7 @@ PerfExpert can sort the hotspots according to:
 \begin{enumerate}
   \item  \strong{Relevance}: Sorted according to their relevance in \% of the total runtime. The code blocks were the execution time is higher will be presented on top. But those code blocks might already be programmed in a full professional and well-performing manner, and maybe cannot be optimised anymore.
   \item  \strong{Performance}: Sorted according to their performance. The code blocks with the worst performance will be presented on top. These code blocks bears the potential to generate the best performance improvement.
-  \item  \strong{Mixed or Impact:} Sorted according to the formula \emph{Relevance x Performance}. The code blocks with a combination of the worst performance and longest execution times (thus having the highest \emph{impact}) are presented on top. Those are the best candidates for optimisation.
+  \item  \strong{Mixed or Impact:} Sorted according to the formula \emph{Relevance $\times$ Performance}. The code blocks with a combination of the worst performance and longest execution times (thus having the highest \emph{impact}) are presented on top. Those are the best candidates for optimisation.
 \end{enumerate}
 
 By default, PerfExpert will list its hotspots unsorted.
@@ -91,7 +91,7 @@ Based on the characteristics revealed during profiling, PerfExpert is able to pr
 
 These recommendations are chosen from an extensive database of scenarios based upon the profiling results, not necessarily code analysis. Certain recommendations may not be applicable to the code base being analysed, nor may they necessarily improve performance. It is up to the user to understand the code being analysed, and then determine if a given recommendation makes sense.
 
-All the possible recommendations are listed and described in Annex 2: Optimisation . Future version of PerfExpert may extend this list of recommendations.
+All the possible recommendations are listed and described in Annex 2: Optimisation. Future version of PerfExpert may extend this list of recommendations.
 
 \section{Optimising the efficiency of a subroutine}
 \label{sec:Optimizing_the_efficiency_of_a_subroutine}
@@ -101,7 +101,7 @@ All the possible recommendations are listed and described in Annex 2: Optimisati
 
 Optimising the ``Instruction Ratios'' means most of the time increase vectorisation and lower the instruction percentages for ``Data access''. You will use the specific metrics of the Data Access categories (L1, L2, L3, LLC misses and Data TLB), which will be discussed later on.
 
-But we want to show you the effect that ``Accessing Data'' has on the overall performance. We have slightly adapted the matrix multiplication program, so that it uses the values of a[i][k] (which was i+k) and b[k][j] (which was k-j directly:
+But we want to show you the effect that ``Accessing Data'' has on the overall performance. We have slightly adapted the matrix multiplication program, so that it uses the values of a[i][k] (which was i+k) and b[k][j] (which was k-j) directly:
 
 Explore the mm1.c program.
 
@@ -160,7 +160,7 @@ Now, lets see what happens if we would compile the same program with FULL optimi
 ...
 \end{prompt}
 
-The program is now able to \textit{`vectorise'} much better.
+The program is now able to ``\textit{vectorise}'' much better.
 
 Of course, in the first place we need to design our program in such a way that the compiler is able to vectorise. A situation where we create a read/write data dependency within the loop (e.g., for \ldots\  \{ a[i+1] = a[i] * c[i]; \} ) shall be avoided, as such program logic may not allow the compiler to ``vectorise'' this loop.
 
@@ -443,5 +443,6 @@ for (i = 0; i < n; i++)
 %\shellcmd{gcc -g -o test6\_i1 test6\_i1.c}%
 %\shellcmd{perfexpert -c 0.3 ./test6\_i1}%
 \end{prompt}
+
 And note the improvement.
 

--- a/perfexpert/ch04_multi_core_multi_job.tex
+++ b/perfexpert/ch04_multi_core_multi_job.tex
@@ -11,7 +11,7 @@ PerfExpert will read hardware performance counter events of the various cores an
 
 As such, optimising a parallel application with PerfExpert is done in exactly the same way as a serial application. PerfExpert handles all additional complexity under the hood; the user gets the same kind of report.
 
-We have created 3 parallel equivalents of the Matrix Multiplication program, one in OpenMP, one in MPI and one with a combination of both. It is interesting to see how much we can reduce the runtime of our application by spreading all the work over the different cores. We have adapted the size of the matrices in the examples to [2000x2000] as to increase the workload a bit.
+We have created 3 parallel equivalents of the Matrix Multiplication program, one in OpenMP, one in MPI and one with a combination of both. It is interesting to see how much we can reduce the runtime of our application by spreading all the work over the different cores. We have adapted the size of the matrices in the examples to [2000 $\times$ 2000] as to increase the workload a bit.
 
 First we, go to the directory of the examples of Chapter04:
 
@@ -73,12 +73,12 @@ For VSC, first load the MPI module:
 %\shellcmd{module load impi}%
 \end{prompt}
 
-\begin{tabular}{|p{0.3\textwidth}|p{0.7\textwidth}} \hline
+\begin{tabular}{|p{\dimexpr 0.3\textwidth-2\tabcolsep}|p{\dimexpr 0.7\textwidth-2\tabcolsep}|} \hline
 \textbf{Institute}          & \textbf{Command} \\ \hline
 TACC                        & \$ \textbf{module load impi} \\ \hline
 VSC                         & \$ \textbf{module load impi} \\ \hline
-VUBrussel                   & \$ \textbf{module load openmpi/1.6.5/gcc/4.8.2}
-                              \$ \textbf{module load impi} \\ \hline
+VUBrussel                   & \$ \textbf{module load openmpi/1.6.5/gcc/4.8.2} \\
+                            & \$ \textbf{module load impi} \\ \hline
 \end{tabular}
 
 
@@ -93,7 +93,7 @@ The command line to run PerfExpert includes the MPI launcher script (i.e., mpiru
 The command becomes:
 
 \begin{prompt}
-%\shellcmd{perfexpert -p ``mpirun'' -c 0.1 ./mm\_mpi}%
+%\shellcmd{perfexpert -p "mpirun" -c 0.1 ./mm\_mpi}%
 [perfexpert] Collecting measurements [hpctoolkit]
 [perfexpert]    [1] 11.375589158 seconds (includes measurement overhead)
 [perfexpert]    [2] 11.637017437 seconds (includes measurement overhead)

--- a/perfexpert/ch05_more_perfexpert_functionality.tex
+++ b/perfexpert/ch05_more_perfexpert_functionality.tex
@@ -13,9 +13,10 @@ If your program would normally executed by the command:
 \begin{prompt}
 %\shellcmd{my\_prog -n 1000 --s 50}%
 \end{prompt}
+
 the PerfExpert command line would become:
 \begin{prompt}
-%\shellcmd{perfexpert 0.1 ./my\_prog `` -n 1000 -s 50''}%
+%\shellcmd{perfexpert 0.1 ./my\_prog "-n 1000 -s 50"}%
 \end{prompt}
 
 \subsection{Input/Output pipes}
@@ -27,6 +28,7 @@ If your program would normally executed by the command:
 \begin{prompt}
 %\shellcmd{my\_prog $<$ input\_file}%
 \end{prompt}
+
 the PerfExpert command line would become:
 \begin{prompt}
 %\shellcmd{perfexpert -i input\_file 0.1 ./my\_prog}%
@@ -86,7 +88,7 @@ The automatic optimisation is achieved by using one the 2 extra options:
 
 If you select the~-m~option and the application is composed of multiple files, your source code tree should have a Makefile file to enable PerfExpert compile your code. If your application is composed of a single source code file, the option~-s~is sufficient for you. If you do not select~-m~or~-s~options, PerfExpert requires only the binary code and will show you only the performance analysis report and the list of suggestion for bottleneck remediation.
 
-\strong{Caution:~} PerfExpert may, if you choose to use the full capabilities for automated optimisation, change your source code during the process of optimisation. PerfExpert always saves the original file with a different name (e.g., mm_omp.c.old\_27301) as well as adds annotations to your source code for each optimisation it makes. We cannot, however, fully guarantee that code modifications for optimisations will not break your code. We recommend having a full backup of your original source code before using PerfExpert.
+\strong{Caution:~} PerfExpert may, if you choose to use the full capabilities for automated optimisation, change your source code during the process of optimisation. PerfExpert always saves the original file with a different name (e.g., mm\_omp.c.old\_27301) as well as adds annotations to your source code for each optimisation it makes. We cannot, however, fully guarantee that code modifications for optimisations will not break your code. We recommend having a full backup of your original source code before using PerfExpert.
 
 \subsection{Automatic Optimisation of single source file}
 \label{subsec:Automatic_Optimization}
@@ -94,7 +96,7 @@ If you select the~-m~option and the application is composed of multiple files, y
 PerfExpert will automatically try a number of code transformations, and it will recompile it for every attempt according to a default compilation command:
 
 \begin{prompt}
-gcc --O3 --g --o $<$binary-file$>$  $<$source-file$>$
+gcc -O3 -g -o <binary-file> <source-file>
 \end{prompt}
 
 Now, try it on a sequential source:
@@ -110,7 +112,7 @@ gcc -O3 -g -o mm mm.c
 
 You can use CC, CFLAGS and LDFLAGS to select different compiler and compilation/linkage flags. The command line would become:
 \begin{prompt}
-%\shellcmd{CC=''icc'' CFLAGS=''-g -O2 '' perfexpert -s mm.c -r50 0.05 ./mm}%
+%\shellcmd{CC="icc" CFLAGS="-g -O2" perfexpert -s mm.c -r50 0.05 ./mm}%
 \end{prompt}
 
 When using PerfExpert's automatic optimisations on the OpenMP version of the simple matrix multiply code, and if we want that the OpenMP-enabled binary will run with 16 threads, we will use the following command line options:
@@ -118,14 +120,14 @@ When using PerfExpert's automatic optimisations on the OpenMP version of the sim
 %\shellcmd{OMP\_NUM\_THREADS=16 CFLAGS="-fopenmp" perfexpert -s mm\_omp.c -r50 0.05 ./mm\_omp}%
 \end{prompt}
 
-In this case, PerfExpert will compile the mm_omp.c code using the system's default compiler, which is GCC in the case of Stampede. PerfExpert will take into consideration only code fragments (loops and functions) that take more 5\% of the runtime.
+In this case, PerfExpert will compile the mm\_omp.c code using the system's default compiler, which is GCC in the case of Stampede. PerfExpert will take into consideration only code fragments (loops and functions) that take more 5\% of the runtime.
 
 To select a different compiler, you should specify the CC environment variable as below:
 \begin{prompt}
 %\shellcmd{CC="icc" OMP\_NUM\_THREADS=16 CFLAGS="-fopenmp" perfexpert -s mm\_omp.c -r50 0.05 ./mm\_omp}%
 \end{prompt}
 
-\subsection{~Automatic Optimisation of multiple source files}
+\subsection{Automatic Optimisation of multiple source files}
 \label{subsec:Automatic_Optimization_multiple}
 
 The same approach can be followed with multiple source files. In his case, the user need to create a Makefile, which can be used to recompile the executable.
@@ -147,7 +149,7 @@ And run in automatic mode:
 \section{Running PerfExpert in Batch mode (with Job Script)}
 \label{sec:Batch_Mode}
 
-One can also run perfexpert in batch mode. This is often desired when the runtime of the program is a bit higher, and you do not want to wait for the results.  You can replace the normal command line to start up your executable (e.g., ``./mm_omp'') in the job script with the perfexpert command line. (e.g., ``\textit{perfexpert -c 0.3 mm_omp}''). When running your application with a job script, be sure to specify a running time that is about 6x the normal running time of the program.
+One can also run perfexpert in batch mode. This is often desired when the runtime of the program is a bit higher, and you do not want to wait for the results.  You can replace the normal command line to start up your executable (e.g., ``./mm\_omp'') in the job script with the perfexpert command line. (e.g., ``\textit{perfexpert -c 0.3 mm\_omp}''). When running your application with a job script, be sure to specify a running time that is about 6x the normal running time of the program.
 
 Compile the parallel Matrix Multiplication program, explore the job-script and submit the job:
 
@@ -156,7 +158,7 @@ Compile the parallel Matrix Multiplication program, explore the job-script and s
 %\shellcmd{more mm\_omp.job}%
 \end{prompt}
 
-\begin{tabular}{|p{0.3\textwidth}|p{0.7\textwidth}} \hline
+\begin{tabular}{|p{\dimexpr 0.3\textwidth-2\tabcolsep}|p{\dimexpr 0.7\textwidth-2\tabcolsep}|} \hline
 \strong{Institute}  & \strong{Command} \\ \hline
 TACC                & \$ \strong{sbatch mm\_omp.job} \\ \hline
 VSC                 & \$ \strong{qsub mm\_omp.job} \\ \hline
@@ -168,10 +170,10 @@ When the job is finished, the generated report can be viewed in the file in our 
 
 \begin{prompt}
 %\shellcmd{ls}%
-\dots
+...
 MyJob.o2225027
 MyJob.e2225027
-\dots
+...
 %\shellcmd{more MyJob.o2225027}%
 [perfexpert] Collecting measurements [hpctoolkit]
 [perfexpert]    [1] 1.992842066 seconds (includes measurement overhead)
@@ -181,6 +183,6 @@ MyJob.e2225027
 ---------------------------------------------------------------------------
 Total running time for mm_omp is 8.86 seconds between all 16 cores
 The wall-clock time for mm_omp is approximately 0.55 seconds
-\dots
+...
 \end{prompt}
 

--- a/perfexpert/perfexpert.tex
+++ b/perfexpert/perfexpert.tex
@@ -14,10 +14,11 @@
 \include{title}
 
 \glsaddall
+\glstoctrue
 \printglossaries
 
 \cleardoublepage
-\addcontentsline{toc}{chapter}{Index}
+%\addcontentsline{toc}{chapter}{Index}
 \printindex
 
 \tableofcontents

--- a/perfexpert/title.tex
+++ b/perfexpert/title.tex
@@ -46,7 +46,7 @@ Acknowledgement: TACC-staff, Susan H.\ Mehringer
 
 \strong{Audience:}
 
-This PerfExpert Tutorial is designed for \strong{HPC-Users} at the \strong{University of Texas}, the members of the \strong{Flemish Supercomputing Centre (VSC)}, being the \strong{University of Antwerp}, the \strong{University of Gent}, The \strong{Catholic University of Leuven}, the \strong{University of Brussels} and the \strong{University of Hasselt} and affiliated institutes who want to profile and optimise their applications.
+This PerfExpert Tutorial is designed for \strong{HPC-Users} at the \strong{University of Texas}, the members of the \strong{Flemish Supercomputing Centre (VSC)}, being the \strong{Antwerp University Association}, the \strong{Brussels University Association}, the \strong{Ghent University Association}, the \strong{Hasselt University Association}, and the \strong{KU Leuven Association} who want to profile and optimise their applications.
 
 The audience may be completely unaware of the profiling and optimisation concepts but must have some basic understanding of HPC programming.
 
@@ -91,7 +91,7 @@ A ``Tip'' paragraph is used for remarks or tips.
 Before starting the course, the example programs and configuration files used in this PerfExpert Tutorial must be copied to your own work directory.
 
 \iftacc
-The examples can also be downloaded from \url{https://portal.tacc.utexas.edu/user-services/training/} or copied from the training directory  ``\emph{\tutorialdir/perfexpert/examples}'' on Stampede to your home directory.
+The examples can also be downloaded from \url{https://portal.tacc.utexas.edu/training/} or copied from the training directory  ``\emph{\tutorialdir/perfexpert/examples}'' on Stampede to your home directory.
 \fi
 \ifvsc
 If you have received a new VSC account, all examples are present in the tutorials directory. In order to have your own local copy, copy the full directory to your home directory.


### PR DESCRIPTION
- fixed typos
- updated TACC url
- changed tabular header for full page width tables
- make Glossary appear automatically in TOC instead of using addcontentsline
- updated Makefile: no OS versions needed for perfexpert