### PR TITLE
use datestamp as version + check for version bump when intro-HPC/*.tex files are changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ env:
       # and replace it below
       - secure: 2p42CdapsQR6xkcR/cnqngbwwYqol7QKosxa6n7r4HhKFw7pcaSRWa/5fLOKIunMxW56UfQgTHCecGAU5/oWS8jmEVZYpBThynQBsHBt4xtPw4RUJzAwn6BmWeKX4RHKE6CCcscxAa1Q9vxBWJ0/yRLSP/ikfj6cAH33ga00dFA=
 before_install:
+    # verify SHA256 checksums to ensure version is bumped when changes are made
+    # if this check fails, you should run ./check-version.sh intro-HPC and commit the changes made by the script
+    - INTRO_HPC_EXPECTED="20170823.01 965d34300067db2e0230c9f4281f3c408daa5c26b860c3e61669cf3069a2b73c"
+    - ./check-version.sh intro-HPC | grep "Checksum for intro-HPC is still valid"
     - cd $HOME
     - travis_retry wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
     - tar -xzf install-tl-unx.tar.gz ; cd install-tl-*/

--- a/check-version.sh
+++ b/check-version.sh
@@ -51,8 +51,7 @@ if [ -z $checksum_tool ]; then
     exit 4
 fi
 
-mkdir -p /tmp/$USER
-tmpfile=$(mktemp /tmp/$USER/XXXXX)
+tmpfile=$(mktemp /tmp/${USER}_XXXXX)
 
 find $dir -name '*.tex' | sort -u | xargs $checksum_tool > $tmpfile
 new_checksum=$($checksum_tool $tmpfile | cut -f1 -d' ')
@@ -81,7 +80,7 @@ else
     echo "New version: $new_version"
 
     # inject new version
-    sed -i.bak "s/Version ${curr_version}/Version ${new_version}/g" $curr_version_file
+    sed -i.bak "s/Version ${curr_version}/Version ${new_version}/" $curr_version_file
 
     # need to recompute checksum after injecting new version...
     find $dir -name '*.tex' | sort -u | xargs $checksum_tool > $tmpfile

--- a/check-version.sh
+++ b/check-version.sh
@@ -52,7 +52,7 @@ if [ -z $checksum_tool ]; then
 fi
 
 function compute_checksum() {
-    tmpfile=$(mktemp /tmp/${USER}_XXXXX)
+    tmpfile=$(mktemp)
     find $1 -name '*.tex' | sort -u | xargs $checksum_tool > $tmpfile
     $checksum_tool $tmpfile | cut -f1 -d' '
     rm $tmpfile

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -u
+
+if [ -z ${1:-} ]; then
+    echo "ERROR: Usage: $0 <directory>" >&2
+    exit 1
+fi
+dir=${1:-}
+
+if [ ! -d $dir ]; then
+    echo "ERROR: Non-existing directory '$dir' specified" >&2
+    exit 2
+fi
+
+# determine current version & checksum for specified directory
+curr_version_line=$(grep '^\\LARGE Version' $dir/*.tex)
+curr_version_file=$(echo $curr_version_line | cut -f1 -d:)
+curr_version=$(echo $curr_version_line | cut -f2 -d: | cut -f3 -d' ')
+if [ -z $curr_version ]; then
+    echo "ERROR: Failed to determine current version for '$dir'" >&2
+    exit 3
+else
+    echo "Current version for $dir: $curr_version (found in $curr_version_file)"
+fi
+
+travis_label=$(echo $dir | tr '[[:lower:]]' '[[:upper:]]' | tr '-' '_')
+curr_checksum=$(grep "${travis_label}_EXPECTED=" .travis.yml | sed 's/.* \(.*\)"$/\1/g')
+if [ -z $curr_checksum ]; then
+    echo "ERROR: Failed to determine current checksum for '$dir'" >&2
+    exit 4
+else
+    echo "Current checksum for $dir: $curr_checksum"
+fi
+
+# compute new checksum, to check whether current version/checksum is up-to-date
+for checksum_tool_cand in sha256sum shasum;
+do
+    which $checksum_tool_cand > /dev/null
+    if [ $? -eq 0 ]; then
+        checksum_tool=$checksum_tool_cand
+        break
+    fi
+done
+if [ "x$checksum_tool" == "xshasum" ]; then
+    checksum_tool="shasum -a 256"
+fi
+
+if [ -z $checksum_tool ]; then
+    echo "ERROR: No checksum tool found!" >&2
+    exit 4
+fi
+
+mkdir -p /tmp/$USER
+tmpfile=$(mktemp /tmp/$USER/XXXXX)
+
+find $dir -name '*.tex' | sort -u | xargs $checksum_tool > $tmpfile
+new_checksum=$($checksum_tool $tmpfile | cut -f1 -d' ')
+echo "Computed checksum for $dir: $new_checksum"
+
+# check current and computed checksums
+if [ "x$curr_checksum" == "x$new_checksum" ]; then
+    echo "Checksum for $dir is still valid, no changes detected, version does not need to be bumped"
+else
+    echo "Mismatch between current and computed checksums for $dir, version need to be bumped..."
+    datestamp=$(date +%Y%m%d)
+    echo $curr_version | grep $datestamp > /dev/null
+    if [ $? -eq 0 ]; then
+        # if current datestamp matches in current version, we need to bump the 2-digit 'minor' version number...
+        curr_minor_ver=$(echo $curr_version | cut -f2 -d.)
+        if [ $curr_minor_ver -eq 99 ]; then
+            echo "ERROR: Ran out of minor version numbers, found .99" >&2
+            exit 5
+        fi
+        new_minor_ver=$(expr $curr_minor_ver + 1)
+        new_version=${datestamp}.$(printf "%02d" ${new_minor_ver})
+    else
+        new_version="${datestamp}.01"
+    fi
+
+    echo "New version: $new_version"
+
+    # inject new version
+    sed -i.bak "s/Version ${curr_version}/Version ${new_version}/g" $curr_version_file
+
+    # need to recompute checksum after injecting new version...
+    find $dir -name '*.tex' | sort -u | xargs $checksum_tool > $tmpfile
+    new_checksum=$($checksum_tool $tmpfile | cut -f1 -d' ')
+
+    sed -i.bak "s/${travis_label}_EXPECTED=\".*\"/${travis_label}_EXPECTED=\"$new_version $new_checksum\"/g" .travis.yml
+
+    rm ${curr_version_file}.bak .travis.yml.bak
+fi
+
+
+rm $tmpfile

--- a/intro-HPC/title.tex
+++ b/intro-HPC/title.tex
@@ -5,7 +5,7 @@
 \vspace*{1.5\baselineskip}
 
 \Huge \strong{HPC Tutorial} \\
-\LARGE Version 1.1
+\LARGE Version 20170823.01
 
 \ifwindows
 \LARGE For Windows Users


### PR DESCRIPTION
The version of `intro-HPC` has been `1.1` for quite a while now...

I propose to start using a datestamp (+ minor 2-digit version number) as a version, which is more meaningful; for example: `20170823.01`, i.e. the first update done on Aug 23rd 2017.

In addition, we should have automated checking of whether the version number was indeed bumped when changes were made, to avoid overlooking this in the future.

The `check-version.sh` script included here has two purposes:

* it can be used to automatically bump the version if any changes were made to the `*.tex` files
* it can be used in the Travis config file to verify whether the version was indeed bumped when changes were made to `*.tex`