### PR TITLE
Minor typographic changes (UAntwerpen, 2017.10-01)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 before_install:
     # verify SHA256 checksums to ensure version is bumped when changes are made
     # if this check fails, you should run ./check-version.sh intro-HPC and commit the changes made by the script
-    - INTRO_HPC_EXPECTED="20170823.01 965d34300067db2e0230c9f4281f3c408daa5c26b860c3e61669cf3069a2b73c"
+    - INTRO_HPC_EXPECTED="20171010.01 55734c300adb09e85194aa250aae98005c93f9ef8fb76d490a00e46234493621"
     - ./check-version.sh intro-HPC | grep "Checksum for intro-HPC is still valid"
     - cd $HOME
     - travis_retry wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz

--- a/glossary.tex
+++ b/glossary.tex
@@ -188,11 +188,11 @@
   name={TACC},
   description={Texas Advanced Computing Center (creators of the PerfExpert tool)},
 }
-\newglossaryentry{UA}
-{
-  name={UA},
-  description={University of Antwerp (creators of this tutorial)},
-}
+%\newglossaryentry{UA}
+%{
+%  name={UA},
+%  description={University of Antwerp (creators of this tutorial)},
+%}
 \newglossaryentry{Walltime}
 {
   name={Walltime},

--- a/intro-HPC/ch_account.tex
+++ b/intro-HPC/ch_account.tex
@@ -27,7 +27,7 @@ See \autoref{ch:hpc-policies} for more information on who is entitled to an acco
 
 The VSC, abbreviation of Flemish Supercomputer Centre, is a virtual
 supercomputer centre. It is a partnership between the five Flemish
-associations: the Association KULeuven,  Ghent University Association, Brussels
+associations: the Association KU~Leuven,  Ghent University Association, Brussels
 University Association, Antwerp University Association and the University
 Colleges-Limburg. The VSC is funded by the Flemish Government.
 
@@ -319,7 +319,7 @@ Directory. (i.e., /Users/$<$username$>$/.ssh/id\_rsa.pub).
 
 \ifgent
   You will now have to log in with CAS using your UGent account, and then be requested
-  to share your Mail and Affiliation with KU Leuven (which actually means the VSC accountpage).
+  to share your Mail and Affiliation with KU~Leuven (which actually means the VSC accountpage).
   Select the ``Remember'' check-box and click ``Yes, continue''.
   \begin{center}
   \includegraphics*[width=5.73in, height=4.00in, keepaspectratio=false]{ch2-browser-authenticate-gent}

--- a/intro-HPC/ch_fine_tuning_job_specifications.tex
+++ b/intro-HPC/ch_fine_tuning_job_specifications.tex
@@ -386,7 +386,7 @@ to request all cores of a node, or
 
 to request half of them.
 
-% KULeuven, UAntwerpen, VUB: please check whether the ppn=all/ppn=half directives also work at your site
+% KU~Leuven, UAntwerpen, VUB: please check whether the ppn=all/ppn=half directives also work at your site
 
 Note that unless a job has some inherent parallelism of
 its own through something like MPI or OpenMP, requesting more than a single

--- a/intro-HPC/ch_running_jobs_with_input_output_data.tex
+++ b/intro-HPC/ch_running_jobs_with_input_output_data.tex
@@ -559,7 +559,7 @@ With this command, you can follow up the consumption of your total disk quota
 easily, as it is expressed in percentages. Depending of on which cluster you are
 running the script, it may not be able to show the quota on all your folders.
 E.g., when running on the tier-1 system Muk, the script will not be able to show
-the quota on \$VSC\_HOME or \$VSC\_DATA if your account is a KU Leuven, UAntwerpen or VUB account.
+the quota on \$VSC\_HOME or \$VSC\_DATA if your account is a KU~Leuven, UAntwerpen or VUB account.
 
 Once your quota is (nearly) exhausted, you will want to know which directories
 are responsible for the consumption of your disk space. You can check the size

--- a/intro-HPC/title.tex
+++ b/intro-HPC/title.tex
@@ -5,7 +5,7 @@
 \vspace*{1.5\baselineskip}
 
 \Huge \strong{HPC Tutorial} \\
-\LARGE Version 20170823.01
+\LARGE Version 20171010.01
 
 \ifwindows
 \LARGE For Windows Users

--- a/intro-HPC/title.tex
+++ b/intro-HPC/title.tex
@@ -1,4 +1,4 @@
-\begin{center}
+ \begin{center}
 
 \includegraphics*[width=8truecm]{logo_vsc}
 
@@ -177,11 +177,11 @@ More documentation can be found at:
   \item  External documentation (TORQUE, Moab): \url{http://docs.adaptivecomputing.com}
 \end{enumerate}
 
-This tutorial \strong{(\version)} is intended for users who want to connect and work on the HPC of the \strong{\university}.
+This tutorial is intended for users who want to connect and work on the HPC of the \strong{\university}.
 
 This tutorial is available in a Windows, Mac or Linux version.
 
-This tutorial is available for UAntwerpen, UGent, KULeuven, UHasselt and VUB users.
+This tutorial is available for UAntwerpen, UGent, KU~Leuven, UHasselt and VUB users.
 
 Request your appropriate version at \hpcinfo.
 

--- a/intro-Linux/ch_filesystems.tex
+++ b/intro-Linux/ch_filesystems.tex
@@ -51,9 +51,9 @@ Space is limited on the cluster's storage, you can check your quota with the
 
 \begin{prompt}
 %\shellcmd{show\_quota}%
-VSC\_HOME: used 1.89 GiB (66%\%%) quota 2.85 GiB (3 GiB hard limit)
-VSC\_DATA: used 0 B (0%\%%) quota 23.8 GiB (25 GiB hard limit)
-VSC\_SCRATCH\_DELCATTY: used 0 B (0%\%%) quota 23.8 GiB (25 GiB hard limit)
+VSC_HOME: used 1.89 GiB (66%\%%) quota 2.85 GiB (3 GiB hard limit)
+VSC_DATA: used 0 B (0%\%%) quota 23.8 GiB (25 GiB hard limit)
+VSC_SCRATCH_DELCATTY: used 0 B (0%\%%) quota 23.8 GiB (25 GiB hard limit)
 \end{prompt}
 
 Quota for personal directories is limited to 3GiB (home) and 25GiB (data \&

--- a/intro-Linux/ch_getting_started.tex
+++ b/intro-Linux/ch_getting_started.tex
@@ -86,7 +86,7 @@ For example, to print the path to your home directory, we can use the shell vari
 
 \begin{prompt}
 %\shellcmd{echo \$HOME}%
-/user/home/gent/vsc400/vsc40000
+%\homedir%
 \end{prompt}
 
 This prints the value of this variable.
@@ -149,9 +149,9 @@ This may lead to surprising results, for example:
 %\shellcmd{export WORKDIR=/tmp/test}%
 %\shellcmd{cd \$WROKDIR}%
 %\shellcmd{pwd}%
-  /user/home/gent/vsc400/vsc40000
+%\homedir%
 %\shellcmd{echo \$HOME}%
-  /user/home/gent/vsc400/vsc40000
+%\homedir%
 \end{prompt}
 
 To understand what's going on here, see the section on ``cd'' below.

--- a/intro-Linux/ch_uploading_files.tex
+++ b/intro-Linux/ch_uploading_files.tex
@@ -26,8 +26,7 @@ symlinks to them in our home directory.
 %\shellcmd{ln -s \$VSC\_SCRATCH scratch}%
 %\shellcmd{ln -s \$VSC\_DATA data}%
 %\shellcmd{ls -l scratch data}%
-%\shellcmd{ls -l scratch data}%
-lrwxrwxrwx 1 %\userid% %\userid% 31 Mar 27  2009 data -> %\homedir%
+lrwxrwxrwx 1 %\userid% %\userid% 31 Mar 27  2009 data -> %\datadir%
 lrwxrwxrwx 1 %\userid% %\userid% 34 Jun  5  2012 scratch -> %\scratchdir%
 \end{prompt}
 

--- a/intro-Linux/title.tex
+++ b/intro-Linux/title.tex
@@ -109,11 +109,11 @@ More documentation can be found at:
   \item  External documentation (TORQUE, Moab): \url{http://docs.adaptivecomputing.com}
 \end{enumerate}
 
-This tutorial \strong{(\version)} is intended for users working on \strong{\OS} who want to connect to the HPC of the \strong{\university}.
+This tutorial is intended for users working on \strong{\OS} who want to connect to the HPC of the \strong{\university}.
 
 This tutorial is available in a Windows, Mac or Linux version.
 
-This tutorial is available for UAntwerpen, UGent, KULeuven, UHasselt and VUB users.
+This tutorial is available for UAntwerpen, UGent, KU~Leuven, UHasselt and VUB users.
 
 Request your appropriate version at \hpcinfo.
 

--- a/macros.tex
+++ b/macros.tex
@@ -25,7 +25,6 @@
 \newcommand{\macro}[2]{\addtext{\string#1}\settext{\string#1}{\noexpand#2}\newcommand{#1}{#2\xspace}}
 
 % Define some general macros
-\macro{\version}{Version 1.1}
 \ifwindows
 \macro{\OS}{Windows}
 \fi

--- a/perfexpert/title.tex
+++ b/perfexpert/title.tex
@@ -46,7 +46,7 @@ Acknowledgement: TACC-staff, Susan H.\ Mehringer
 
 \strong{Audience:}
 
-This PerfExpert Tutorial is designed for \strong{HPC-Users} at the \strong{University of Texas}, the members of the \strong{Flemish Supercomputing Centre (VSC)}, being the \strong{Antwerp University Association}, the \strong{Brussels University Association}, the \strong{Ghent University Association}, the \strong{Hasselt University Association}, and the \strong{KU Leuven Association} who want to profile and optimise their applications.
+This PerfExpert Tutorial is designed for \strong{HPC-Users} at the \strong{University of Texas}, the members of the \strong{Flemish Supercomputing Centre (VSC)}, being the \strong{Antwerp University Association}, the \strong{Brussels University Association}, the \strong{Ghent University Association}, the \strong{Hasselt University Association}, and the \strong{KU~Leuven Association} who want to profile and optimise their applications.
 
 The audience may be completely unaware of the profiling and optimisation concepts but must have some basic understanding of HPC programming.
 

--- a/sites/antwerpen/contact-information.tex
+++ b/sites/antwerpen/contact-information.tex
@@ -1,14 +1,13 @@
 \begin{enumerate}
 \item  By e-mail:  \hpcinfo
 \item  By phone: 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert), 03/2653852 (Kurt)
-\item  In real: Campus Middelheim, Building G, Room G.309 and G.310
+\item  In real: Campus Middelheim, Building G, Rooms G.309, G.310 and G.311
 \end{enumerate}
 
 Mailing-lists:
 
 \begin{enumerate}
 \item  Announcements: \hpcannounceml (for official announcements and communications)
-\item  Users: \hpcusersml (for discussions between users)
 \end{enumerate}
 
 New users are automatically added to both mailing lists.

--- a/sites/antwerpen/macros.tex
+++ b/sites/antwerpen/macros.tex
@@ -1,4 +1,4 @@
-sites/antwerpen/contact-information.tex% University Definitions
+% University Definitions
 \macro{\sitename}{antwerpen}
 \macro{\university}{University of Antwerp}
 \macro{\association}{Antwerp University Association (AUHA)}

--- a/sites/antwerpen/macros.tex
+++ b/sites/antwerpen/macros.tex
@@ -1,4 +1,4 @@
-% University Definitions
+sites/antwerpen/contact-information.tex% University Definitions
 \macro{\sitename}{antwerpen}
 \macro{\university}{University of Antwerp}
 \macro{\association}{Antwerp University Association (AUHA)}
@@ -19,8 +19,9 @@
 \macro{\examplesdir}{/apps/antwerpen/tutorials/Intro-HPC/examples}
 % Demo user, jobs, nodes, etc
 \macro{\userid}{vsc20167}
-\macro{\homedir}{/user/antwerpen/201/vsc20167}
-\macro{\scratchdir}{/scratch/antwerpen/201/vsc20168}
+\macro{\homedir}{/user/antwerpen/201/\userid}
+\macro{\datadir}{/data/antwerpen/201/\userid}
+\macro{\scratchdir}{/scratch/antwerpen/201/\userid}
 \macro{\jobid}{433253.master1.hopper.antwerpen.vsc}
 \macro{\computenode}{r5c3cn08.hopper.antwerpen.vsc}
 \macro{\computenodeshort}{r5c3cn08}

--- a/sites/brussel/macros.tex
+++ b/sites/brussel/macros.tex
@@ -18,8 +18,9 @@
 \macro{\examplesdir}{/apps/brussel/tutorials/Intro-HPC/examples}
 % Demo user, jobs, nodes, etc
 \macro{\userid}{vsc10002}
-\macro{\homedir}{/user/brussel/100/vsc10002}
-\macro{\scratchdir}{/scratch/brussel/100/vsc10002}
+\macro{\homedir}{/user/brussel/100/\userid}
+\macro{\datadir}{/data/brussel/100/\userid}
+\macro{\scratchdir}{/scratch/brussel/100/\userid}
 \macro{\jobid}{433253.master1.hydra.brussel.vsc}
 \macro{\computenode}{r5e3cn13.hydra.brussel.vsc}
 \macro{\computenodeshort}{r4e2cn03}

--- a/sites/gent/macros.tex
+++ b/sites/gent/macros.tex
@@ -20,8 +20,9 @@
 \macro{\examplesdir}{/apps/gent/tutorials/Intro-HPC/examples}
 % Demo user, jobs, nodes, etc
 \macro{\userid}{vsc40000}
-\macro{\homedir}{/user/home/gent/vsc400/vsc40000}
-\macro{\scratchdir}{/user/scratch/gent/vsc400/vsc40000}
+\macro{\homedir}{/user/home/gent/vsc400/\userid}
+\macro{\datadir}{/user/data/gent/vsc400/\userid}
+\macro{\scratchdir}{/user/scratch/gent/vsc400/\userid}
 \macro{\jobid}{123456.master15.delcatty.gent.vsc}
 \macro{\computenode}{node2001.delcatty.gent.vsc}
 \macro{\computenodeshort}{node2001}

--- a/sites/leuven/contact-information.tex
+++ b/sites/leuven/contact-information.tex
@@ -1,7 +1,7 @@
 \begin{enumerate}
 \item  By e-mail:  \hpcinfo
 \item  By phone: (016) 32 28 00
-\item  In real: KU Leuven, Directie ICTS, Willem de Croylaan 52c - bus 5580, 3001 Heverlee
+\item  In real: KU~Leuven, Directie ICTS, Willem de Croylaan 52c - bus 5580, 3001 Heverlee
 \end{enumerate}
 
 Mailing-lists:

--- a/sites/leuven/macros.tex
+++ b/sites/leuven/macros.tex
@@ -1,11 +1,11 @@
 % University Definitions
 \macro{\sitename}{leuven}
-\macro{\university}{KU Leuven/Hasselt University}
-\macro{\association}{KU Leuven/Hasselt University and their association partners}
+\macro{\university}{KU~Leuven/Hasselt University}
+\macro{\association}{KU~Leuven/Hasselt University and their association partners}
 % HPC definitions
-\macro{\hpc}{HPC-KU Leuven/UHasselt}
-\macro{\hpcInfra}{HPC-KU Leuven/UHasselt}
-\macro{\hpcTeam}{HPC-KU Leuven/UHasselt}
+\macro{\hpc}{HPC-KU~Leuven/UHasselt}
+\macro{\hpcInfra}{HPC-KU~Leuven/UHasselt}
+\macro{\hpcTeam}{HPC-KU~Leuven/UHasselt}
 \macro{\hpcname}{Thinking}
 \macro{\loginnode}{login.hpc.kuleuven.be}
 \macro{\loginhost}{hpc-p-login-1}
@@ -19,8 +19,9 @@
 \macro{\examplesdir}{/apps/leuven/training/Intro-hpc/examples}
 % Demo user, jobs, nodes, etc
 \macro{\userid}{vsc30468}
-\macro{\homedir}{/user/leuven/304/vsc30468}
-\macro{\scratchdir}{/scratch/leuven/304/vsc30468}
+\macro{\homedir}{/user/leuven/304/\userid}
+\macro{\datadir}{/data/leuven/304/\userid}
+\macro{\scratchdir}{/scratch/leuven/304/\userid}
 \macro{\jobid}{21234567.icts-p-svcs-1}
 \macro{\computenode}{r5i0n7.thinking.leuven.vsc}
 \macro{\computenodeshort}{r5i0n7}
@@ -29,5 +30,5 @@
 \macro{\hpcinfo}{HPCinfo@icts.kuleuven.be}
 %\macro{\hpcusersml}{HPCusers@ls.kuleuven.be}
 \macro{\hpcannounceml}{HPCusers@ls.kuleuven.be}
-\macro{\hpcuserguide}{introduction to KULeuven-HPC tutorial}
+\macro{\hpcuserguide}{introduction to KU~Leuven-HPC tutorial}
 \macro{\mpirun}{mpirun}


### PR DESCRIPTION
all files:
- replaced KULeuven / KU Leuven by KU~Leuven

glossary.tex:
- removed UA

macros.tex:
- removed \version (to avoid inconsistencies with titlepage itself)

intro-HPC/title.tex:
- removed \version (to avoid inconsistencies with titlepage itself)

intro-Linux/title.tex:
- removed \version (to avoid inconsistencies with titlepage itself)

intro-Linux/ch_filesystems.tex:
- removed \ in front of _ in a prompt environment

intro-Linux/ch_getting_started.tex:
- replaced Gent specific home directory by \homedir

intro-Linux/ch_uploading_files.tex:
- added \datadir to have consistent output

sites/antwerpen/contact-information.tex:
- updated information

sites/*/macros.tex:
- introduced \datadir
- modified \homedir and \scratchdir to use \userid (to avoid inconsistencies)