### PR TITLE
UAntwerpen minor update Sept 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
 before_install:
     # verify SHA256 checksums to ensure version is bumped when changes are made
     # if this check fails, you should run ./check-version.sh intro-HPC and commit the changes made by the script
-    - INTRO_HPC_EXPECTED="20180904.01 b568dbba7a4f31acd9ea9eb41a47ead06234b919e36ff5413ff1267cac878739"
-    - INTRO_LINUX_EXPECTED="20180903.04 7d4fec7f5f4a25366c075fa112304bc563d58ebcc7a8b3494475eceb587a13d2"
+    - INTRO_HPC_EXPECTED="20180904.04 54ea4dcbaf63510f7a73fc928ddc9b7f6f92c76cdaa9f048ae00d08b8c74757d"
+    - INTRO_LINUX_EXPECTED="20180904.02 b7538bc4ff3c4856f75acdea9d3176a813995f540caa2fd67eac316ea771667f"
     - ./check-version.sh intro-HPC | grep "Checksum for intro-HPC is still valid"
     - ./check-version.sh intro-Linux | grep "Checksum for intro-Linux is still valid"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 before_install:
     # verify SHA256 checksums to ensure version is bumped when changes are made
     # if this check fails, you should run ./check-version.sh intro-HPC and commit the changes made by the script
-    - INTRO_HPC_EXPECTED="20180903.05 e500f82fec3605115f57ab68ed31d2b2f34afca15984f1ef650dd4477d57d1b6"
+    - INTRO_HPC_EXPECTED="20180904.01 b568dbba7a4f31acd9ea9eb41a47ead06234b919e36ff5413ff1267cac878739"
     - INTRO_LINUX_EXPECTED="20180903.04 7d4fec7f5f4a25366c075fa112304bc563d58ebcc7a8b3494475eceb587a13d2"
     - ./check-version.sh intro-HPC | grep "Checksum for intro-HPC is still valid"
     - ./check-version.sh intro-Linux | grep "Checksum for intro-Linux is still valid"

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,12 @@ ifndef DOC
 DOCOS=$(all_doc_os)
 DOCNOOS=$(all_doc_noos)
 else
+ifneq (,$(findstring $(DOC),$(all_doc_os)))
 DOCOS=$(DOC)
+endif
+ifneq (,$(findstring $(DOC),$(all_doc_noos)))
 DOCNOOS=$(DOC)
+endif
 endif
 
 all: all_os all_noos

--- a/intro-HPC/ch_introduction.tex
+++ b/intro-HPC/ch_introduction.tex
@@ -79,7 +79,7 @@ up to 100 Gbit Infiniband fiber connections & \dots\  or allowing to transfer 3 
 The \hpc currently consists of:
 
 \ifantwerpen
-Hopper:
+hopper:
   \begin{enumerate}
     \item  144 compute nodes with 2 ten core Intel E5-2680v2 CPUs (Ivy Bridge generation, 2.8 GHz), 64 GB
     memory, 500 GB local disk
@@ -89,7 +89,7 @@ Hopper:
 All nodes are connected through a FDR10 InfiniBand network.
 
 
-Leibniz:
+leibniz:
   \begin{enumerate}
   \item 144 compute nodes with 2 14-core Intel E5-2680v4 CPUs (Broadwell generation, 2.4 GHz) and 128 GB RAM
   \item 8 nodes with 2 14-core Intel E5-2680v4 CPUs (Broadwell generation, 2.4 GHz) and 256 GB RAM
@@ -148,8 +148,7 @@ All nodes are connected through a EDR InfiniBand network
 \ifantwerpen
 All the nodes in the \hpc run under the ``\operatingsystemCOS'' operating
 system, which is a clone of ``\operatingsystemRHEL'',
-with \emph{cgroups} support. (Until the end of 2017 some nodes of Hopper
-still run under \operatingsystemSL without \emph{cgroups} support.)
+with \emph{cgroups} support. 
 \fi
 \ifleuven
 All the nodes in the \hpc run under the ``\operatingsystem'' operating system.
@@ -299,11 +298,17 @@ GCC and Intel.
 %TODO insert software for other sites
 
 \ifantwerpen
-Commonly used software packages are ABINIT, CP2K, Gaussian, Gromacs, Molpro,
-NWChem, Quantum Espresso, R, Siesta, TURBOMOLE, WIEN2k, \ldots
+Commonly used software packages are:
+\begin{itemize}
+\item{in bioinformatics: beagle, Beast, bowtie, MrBayes, SAMtools}
+\item{in chemistry: ABINIT, CP2K, Gaussian, Gromacs, LAMMPS, NWChem, Quantum Espresso, Siesta, VASP}
+\item{in engineering: COMSOL, OpenFOAM, Telemac}
+\item{in mathematics: JAGS, Matlab, R}
+\item{for visuzalization: Gnuplot, ParaView.}
+\end{itemize}
 
-Commonly used Libraries are Intel MKL, FFTW, HDF5, PETSc and Intel MPI,
-M(VA)PICH, OpenMPI.
+Commonly used libraries are Intel MKL, FFTW, HDF5, PETSc and Intel MPI,
+OpenMPI.
 \fi
 \ifleuven
 Commonly used software packages are:
@@ -317,7 +322,7 @@ Commonly used software packages are:
 \end{itemize}
 
 
-Commonly used Libraries are: Intel MKL, FFTW, HDF5, PETSc, Intel MPI,
+Commonly used libraries are: Intel MKL, FFTW, HDF5, PETSc, Intel MPI,
 M(VA)PICH, OpenMPI, Qt, VTK and Mesa.
 \fi
 \ifbrussel

--- a/intro-HPC/ch_preparing_the_environment.tex
+++ b/intro-HPC/ch_preparing_the_environment.tex
@@ -253,20 +253,7 @@ applications, compile and test them and submit your jobs on the \hpc.
 Intro-HPC/
 \end{prompt}
 
-\ifantwerpen
 This directory currently contains all training material for the \strong{\emph{Introduction to the \hpc}}.
-\else
-This directory currently contains all training material for the use of:
-
-\begin{enumerate}
-\item  The \strong{\emph{Introduction to the \hpc}}.
-%\item  The \strong{\emph{Introduction to Linux}}.
-%\item  The \strong{\emph{Python}} programming language.
-%\item  The \strong{\emph{VI}} editor.
-\item  Introduction to using \strong{\emph{perfexpert}}.
-\end{enumerate}
-\fi
-
 More relevant training material to work with the \hpc can always be added
 later in this directory.
 

--- a/intro-HPC/ch_preparing_the_environment.tex
+++ b/intro-HPC/ch_preparing_the_environment.tex
@@ -253,6 +253,9 @@ applications, compile and test them and submit your jobs on the \hpc.
 Intro-HPC/
 \end{prompt}
 
+\ifantwerpen
+This directory currently contains all training material for the \strong{\emph{Introduction to the \hpc}}.
+\else
 This directory currently contains all training material for the use of:
 
 \begin{enumerate}
@@ -262,6 +265,7 @@ This directory currently contains all training material for the use of:
 %\item  The \strong{\emph{VI}} editor.
 \item  Introduction to using \strong{\emph{perfexpert}}.
 \end{enumerate}
+\fi
 
 More relevant training material to work with the \hpc can always be added
 later in this directory.

--- a/intro-HPC/ch_running_batch_jobs.tex
+++ b/intro-HPC/ch_running_batch_jobs.tex
@@ -217,7 +217,7 @@ since most currently running jobs will finish before their requested walltime
 expires, and new jobs by may be submitted by other users that are assigned a higher
 priority than your job(s).
 
-The \hpcInfra clusters use a fair-share sheduling policy. There is no guarantee on when a
+The \hpcInfra clusters use a fair-share sheduling policy (see \autoref{ch:hpc-policies}). There is no guarantee on when a
 job will start, since it depends on a number of factors. One of these factors is
 the priority of the job, which is determined by
 \begin{itemize}
@@ -580,7 +580,7 @@ are:
 %and evolving, it can be anticipated that also the limits of the categories can
 %be changed over time.
 
-\ifantwerpen
+\iffalse
 % TODO : already adapt this text according to the new common user experience rules, and make it general....
 When a user submits a job with a walltime of 6 days, the queue manager will
 put the job in the walltime category 3 days--7 days.  The user can submit up to 400 jobs with
@@ -667,7 +667,7 @@ broadwell         & only use Intel processors from the Broadwell family (26xx-v4
 mem256            & only use nodes with 256GB of RAM (hopper and leibniz) \\ \hline
 \end{tabular}
 
-Since both Hopper and Leibniz are homogeneous with respect to processor architecture, the CPU architecture properties
+Since both hopper and leibniz are homogeneous with respect to processor architecture, the CPU architecture properties
 are not really needed and only defined for compatibility with other VSC clusters.
 \fi
 \ifbrussel

--- a/intro-HPC/title.tex
+++ b/intro-HPC/title.tex
@@ -5,7 +5,7 @@
 \vspace*{1.5\baselineskip}
 
 \Huge \strong{HPC Tutorial} \\
-\LARGE Version 20180903.05
+\LARGE Version 20180904.01
 
 \ifwindows
 \LARGE For Windows Users

--- a/intro-HPC/title.tex
+++ b/intro-HPC/title.tex
@@ -5,7 +5,7 @@
 \vspace*{1.5\baselineskip}
 
 \Huge \strong{HPC Tutorial} \\
-\LARGE Version 20180904.03
+\LARGE Version 20180904.04
 
 \ifwindows
 \LARGE For Windows Users

--- a/intro-Linux/title.tex
+++ b/intro-Linux/title.tex
@@ -7,7 +7,7 @@
 \vspace*{1.5\baselineskip}
 
 \Huge \strong{Linux Tutorial} \\
-\LARGE Version 20180904.01
+\LARGE Version 20180904.02
 
 \ifwindows
 \LARGE For Windows Users

--- a/sites/antwerpen/contact-information.tex
+++ b/sites/antwerpen/contact-information.tex
@@ -1,6 +1,6 @@
 \begin{enumerate}
 \item  By e-mail:  \hpcinfo
-\item  By phone: 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert), 03/2653852 (Kurt)
+\item  By phone: 03/2653860 (Stefan), 03/2653855 (Franky), 03/2653879 (Bert), 03/2653852 (Kurt), 03/2658980 (Thomas)
 \item  In real: Campus Middelheim, Building G, Rooms G.309, G.310 and G.311
 \end{enumerate}
 

--- a/sites/antwerpen/queue-table.tex
+++ b/sites/antwerpen/queue-table.tex
@@ -1,25 +1,10 @@
-On hopper:
-
 \begin{tabular}{|p{1.4in}|p{1.2in}|p{0.9in}|p{0.9in}|} \hline
 \multicolumn{2}{|p{1.5in}|}{\strong{Walltime}} & \multicolumn{2}{|p{1.4in}|}{\strong{Max \# Jobs}} \\ \hline
 \strong{Minimum / from\newline (value not included)} & \strong{Maximum / to \newline (value included)} & \strong{Queuable} & \strong{Runnable} \\ \hline
 0      & 1 hour  & 2000 & 1000 \\ \hline
-1 hour & 1 day   & 2000 & 300  \\ \hline
-1 day  & 3 days  & 1000 & 200  \\ \hline
-3 days & 7 days  & 400  & 50   \\ \hline
-\end{tabular}
-
-On hopper we do not support jobs running longer than 7 days.
-
-On leibniz:
-
-\begin{tabular}{|p{1.4in}|p{1.2in}|p{0.9in}|p{0.9in}|} \hline
-\multicolumn{2}{|p{1.5in}|}{\strong{Walltime}} & \multicolumn{2}{|p{1.4in}|}{\strong{Max \# Jobs}} \\ \hline
-\strong{Minimum / from\newline (value not included)} & \strong{Maximum / to \newline (value included)} & \strong{Queuable} & \strong{Runnable} \\ \hline
-0      & 1 hour  & 2000 & 1000 \\ \hline
-1 hour & 1 day   & 2000 & 300  \\ \hline
+1 hour & 1 day   & 2000 & 500  \\ \hline
 1 day  & 3 days  & 1000 & 200  \\ \hline
 \end{tabular}
 
-On leibniz we do not support jobs running longer than 3 days.
+We do not support jobs running longer than 3 days.
 


### PR DESCRIPTION
intro-HPC/ch_introduction.tex
- removed old information (Scientific Linux till end 2017)
- updated available software

intro-HPC/ch_preparing_the_environment.tex
- updated contents of tutorial directory

intro-HPC/ch_running_batch_jobs.tex
- removed old information (7 days queue)

sites/antwerpen/contact-information.tex
- added Thomas

sites/antwerpen/queue-table.tex
- updated information