### PR TITLE
$VSC_SCRATCH_LOCAL should be $VSC_SCRATCH_NODE

### DIFF
--- a/intro-HPC/ch_fine_tuning_job_specifications.tex
+++ b/intro-HPC/ch_fine_tuning_job_specifications.tex
@@ -620,7 +620,7 @@ and that you have environment variables which point to these directories availab
 (i.e., \emph{\$VSC\_DATA}, \emph{\$VSC\_SCRATCH} and \emph{\$VSC\_DATA}).
 On top of those, you can also access some temporary storage (i.e., the /tmp
 directory) on the compute node, which is defined by the
-\emph{\$VSC\_SCRATCH\_LOCAL} environment variable.
+\emph{\$VSC\_SCRATCH\_NODE} environment variable.
 
 \ifgent
   % We don't use monitor in Gent


### PR DESCRIPTION
fix for #324 reported by @wdpypere