### PR TITLE
update VNC chapter to cover upcoming changes in HPC-UGent login nodes

### DIFF
--- a/intro-HPC/ch_VNC.tex
+++ b/intro-HPC/ch_VNC.tex
@@ -5,7 +5,7 @@ Virtual Network Computing is a graphical desktop sharing system that enables you
 to interact with graphical software running on HPC infrastructure from your own
 computer.
 
-\section{Start the VNC server}
+\section{Starting a VNC server}
 \label{sec:start-vnc}
 
 First login on the login node (see \autoref{sec:first-time-connection-to-the-hpc}),
@@ -20,59 +20,139 @@ Verify:%\emph{<{}enter the same password>{}}%
 Would you like to enter a view-only password (y/n)? %\emph{n}%
 A view-only password is not used
 
-New '%\strong{login02}%.login.os:%\strong{6}% (%\userid{}%)' desktop is login02.login.os:6
+New '%\strong{\loginhost{}}%:%\strong{6}% (%\userid{}%)' desktop is %\loginhost{}%:6
 
 Creating default startup script %\homedir{}%/.vnc/xstartup
 Creating default config %\homedir{}%/.vnc/config
 Starting applications specified in %\homedir{}%/.vnc/xstartup
-Log file is %\homedir{}%/.vnc/login02.login.os:6.log
+Log file is %\homedir{}%/.vnc/%\loginhost{}%:6.log
 
 \end{prompt}
 
 When prompted for a password, make sure to enter a secure password: if someone
 can guess your password, they will be able to do anything with your account you can.
 
-Note down the details in bold: the hostname (in the example \lstinline|login02|)
-and the port number (in the example \lstinline|6|).
+Note down the details in bold: the hostname (in the example: \texttt{\loginhost{}})
+and the port number (in the example: \lstinline|6|).
 
 It's important to remember that VNC sessions are permanent. They survive network
 problems and (unintended) connection loss. This means you can logout and go home
 without a problem (like the terminal equivalent \lstinline|screen| or \lstinline|tmux|).
 This also means you don't have to start \lstinline|vncserver| each time you want to connect.
 
-\section{Connecting to the VNC server}
+\section{List running VNC servers}
+\label{sec:list-vnc}
 
-\subsection{VNC on the login nodes}
+You can get a list of running VNC servers on a node with
 
-The VNC server runs on a \strong{specific login node} (in this example \lstinline|login02|).
-Make sure you connect to this login node: the domain should be like \lstinline|login02.institute.be|,
-but the number can be different. If you're not sure how to do this, please follow the steps
-in \autoref{sec:first-time-connection-to-the-hpc}, but replace \loginnode with your specific
-domain (here \lstinline|login02.institute.be|).
+\begin{prompt}
+%\shellcmd{vncserver -list}%
+TigerVNC server sessions:
+
+X DISPLAY #	PROCESS ID
+:6		    30713
+\end{prompt}
+
+This only displays the running VNC servers on \strong{the login node you run the command on}.
+
+To see what login nodes you are running a VNC server on, you can run the \lstinline|ls .vnc/*.pid|
+command in your home directory: the files shown have the hostname of the login node in the filename:
+
+\begin{prompt}
+%\shellcmd{cd \$HOME}%
+%\shellcmd{ls .vnc/*.pid}%
+.vnc/%\loginhost{}%:6.pid
+.vnc/%\altloginhost{}%:8.pid
+\end{prompt}
+
+This shows that there is a VNC server running on \texttt{\loginhost{}} on port 5906
+and another one running \texttt{\altloginhost{}} on port 5908 (see also \autoref{sec:source-port-vnc}).
+
+\section{Connecting to a VNC server}
+
+The VNC server runs on a \strong{specific login node} (in the example above, on \texttt{\loginhost{}}).
+
+In order to access your VNC server, you will need to set up an SSH tunnel from your workstation
+to this login node (see \autoref{sec:ssh-tunnel-vnc}).
 
 Login nodes are rebooted from time to time. You can check that the VNC server is still
-running in the same note by executing `vncserver -list`. If you get an empty list,
-it means that \lstinline|vncserver| is not running. You will need to start it again,
-see \autoref{sec:start-vnc}.
+running in the same node by executing \lstinline|vncserver -list| (see also \autoref{sec:list-vnc}).
+If you get an empty list, it means that there is no VNC server running on the login node.
 
-You will now need to portforward the VNC port. The source port is the sum of \lstinline|5900|
-and the number we noted down earlier. In this case, it would be \lstinline|5906|.
-The destination port is the same as the source port. The host is \lstinline|localhost|:
-\lstinline|localhost| here means ``your own computer'': we set up an SSH tunnel that would
-connect the VNC port on the login node to the same port on your local computer.
+\subsection{Determining the source port}
+\label{sec:source-port-vnc}
+
+To set up the SSH tunnel required to connect to your VNC server, you will need to port forward the VNC port
+to your workstation. The \emph{source port} is the sum of \lstinline|5900|
+and the port number we noted down earlier (\lstinline|6|); in this case, that is \lstinline|5906|.
+The \emph{destination port} should be the same as the source port. The \emph{host} is \lstinline|localhost|,
+which means ``your own computer'': we set up an SSH tunnel that connects
+the VNC port on the login node to the same port on your local computer.
+
+\subsection{Setting up the SSH tunnel}
+\label{sec:ssh-tunnel-vnc}
 
 \ifwindows
 See \autoref{par:ssh-tunnel-windows}. Use the details specified here (host, destination port,
 source port).
 \else
 
-Execute the following command. Make sure to replace the port numbers, userid and login node
-with your own.
+Execute the following command to set up the SSH tunnel.\\
+\strong{Replace the port number (\lstinline|5906|) and the user ID (\texttt{\userid{}}) with your own!}
 
 \begin{prompt}
-%shellcmd{ssh -L 5906:localhost:5906 \userid{}@login02.institute.be}
+%\shellcmd{ssh -L 5906:localhost:5906 \userid{}@\loginnode{}}%
 \end{prompt}
 \fi
+
+\subsubsection{Connecting to the right login node}
+
+After setting up the SSH tunnel, you need to make sure you are connected to the correct login node,
+i.e.\ the one on which the VNC server was started (see \autoref{sec:start-vnc}). In the example,
+the VNC server was started on \texttt{\loginhost}.
+
+In the session you created to set up the SSH tunnel, check which login node you are connected to
+using the \lstinline|hostname| command:
+
+\begin{prompt}
+%\shellcmd{hostname}%
+%\altloginhost{}%
+\end{prompt}
+
+Note that in the example above, we are not (yet) connected to the correct login node (i.e., \texttt{\loginhost}).
+
+There are two possible scenarios:
+
+\begin{itemize}
+
+\item If you are connected to the right login node, your SSH tunnel is set up correctly to connect to your VNC server
+      (see \autoref{sec:vnc-client}).
+
+\item If you are connected to a different login node (e.g., \texttt{\altloginhost} rather than \texttt{\loginhost},
+      as shown above), you need to set up another SSH tunnel on the login node you are connected to,
+      to forward the port you will be connecting to from your workstation to the correct login node.
+
+      To set up an SSH tunnel to forward port \lstinline|5906| to \texttt{\loginhost}, run the following command
+      on the login node you are connected to:
+
+\begin{prompt}
+%\shellcmd{ssh -L 5906:localhost:5906 \loginhost{}}%
+%\shellcmd{hostname}%
+%\loginhost{}%
+\end{prompt}
+
+      \strong{Do not forget to change the port (\lstinline|5906|) and hostname of the login node (\texttt{\loginhost})
+              in the command shown above, if needed.}
+
+      As shown above, you can check again using the \lstinline|hostname| command whether you are indeed connected
+      to the right login node.
+\end{itemize}
+
+Once you are connected to the right login node through an SSH tunnel, you can go ahead and connect to yout VNC server
+(see \autoref{sec:vnc-client}).
+
+\subsection{Connecting using a VNC client}
+\label{sec:vnc-client}
 
 \ifwindows
 
@@ -93,8 +173,8 @@ Download and setup a VNC client. A good choice is \lstinline|tigervnc|. You can 
 it with the \lstinline|vncviewer| command.
 \fi
 
-Now start your VNC client and connect to \lstinline|localhost:5906|, again replacing
-the port with your own.
+Now start your VNC client and connect to \lstinline|localhost:5906|.
+\strong{Make sure you replace the port number \lstinline|5906| with your own.}
 
 When promted for a password, use the password you used to setup the VNC server.
 When prompted for default or empty panel, choose default.
@@ -109,6 +189,7 @@ If you have an empty panel, you can reset your settings with the following comma
 \end{prompt}
 
 \section{Stopping the VNC server}
+\label{sec:stop-vnc}
 
 The VNC server can be killed by running
 
@@ -119,34 +200,8 @@ vncserver -kill :6
 where \lstinline|6| is the port number we noted down earlier. If you forgot,
 you can get it with \lstinline|vncserver -list|.
 
-\section{List running VNC servers}
-
-You can get a list of running VNC servers on a node with
-
-\begin{prompt}
-\shellcmd{vncserver -list}
-TigerVNC server sessions:
-
-X DISPLAY #	PROCESS ID
-:6		    30713
-\end{prompt}
-
-This only displays the running VNC servers on \strong{the node you run the command on}.
-
-To see what login nodes you are running a VNC server on, you can use the \lstinline|ls ~/.vnc/*.pid|
-command: the files shown have the hostname of the login node in the filename:
-
-\begin{prompt}
-%\shellcmd{find ~/.vnc -iname '*.pid'  -printf "\%{}f\textbackslash{}n"}%
-login02.login.os:6.pid
-login01.login.os:8.pid
-\end{prompt}
-
-This shows that there is a VNC server running on \lstinline|login02| on port 5906
-and another one running on \lstinline|login01| on port 5908.
-
 \section{I forgot the password, what now?}
 
-You can reset the password by first stopping the VNC server, then removing
-the \lstinline|.vnc/passwd| file (with \lstinline|rm .vnc/passwd|) and then
-starting the VNC server again.
+You can reset the password by first stopping the VNC server (see \autoref{sec:stop-vnc}),
+then removing the \lstinline|.vnc/passwd| file (with \lstinline|rm .vnc/passwd|) and then
+starting the VNC server again (see \autoref{sec:start-vnc}).

--- a/intro-HPC/ch_running_interactive_jobs.tex
+++ b/intro-HPC/ch_running_interactive_jobs.tex
@@ -37,7 +37,7 @@ First of all, in order to know on which computer you're working, enter:
 %\loginhost{}%
 \end{prompt}
 
-This means that you're now working on the login-node ``\emph{\loginnode}'' of
+This means that you're now working on the login node \texttt{\loginhost} of
 the \hpc cluster.
 
 The most basic way to start an interactive job is the following:

--- a/sites/antwerpen/macros.tex
+++ b/sites/antwerpen/macros.tex
@@ -11,6 +11,7 @@
 \macro{\hpcname}{hopper}
 \macro{\loginnode}{login.hpc.uantwerpen.be}
 \macro{\loginhost}{ln02.hopper.uantwerpen.vsc}
+\macro{\altloginhost}{ln01.hopper.uantwerpen.vsc}
 % get these with ssh-keyscan login1-hopper.uantwerpen.be > file
 % ssh-keygen -l -f file
 % ssh-keygen -l -f file -E md5

--- a/sites/brussel/macros.tex
+++ b/sites/brussel/macros.tex
@@ -10,6 +10,7 @@
 \macro{\hpcname}{Hydra}
 \macro{\loginnode}{hydra.vub.ac.be}
 \macro{\loginhost}{nic50.hydra.vub.ac.be}
+\macro{\altloginhost}{nic51.hydra.vub.ac.be}
 \newcommand{\opensshFirstConnect}{ED25519 key fingerprint is SHA256:m0SKm4laT5OGnGaHIxROJ9LEJJqzsbWB+qpjd4GnOyE
 
 RSA key fingerprint is SHA256:xunjQm9tWulj3hkmSf/3EGs7cOThFIa+Zgn2AZyTtbc

--- a/sites/gent/macros.tex
+++ b/sites/gent/macros.tex
@@ -9,7 +9,8 @@
 \macro{\hpcTeam}{UGent HPC team}
 \macro{\hpcname}{hpcugent}
 \macro{\loginnode}{login.hpc.ugent.be}
-\macro{\loginhost}{gligar01.gligar.gent.vsc}
+\macro{\loginhost}{gligar04.gastly.os}
+\macro{\altloginhost}{gligar05.gastly.os}
 % get these with ssh-keyscan gligar01.ugent.be > file
 % ssh-keygen -l -f file
 % ssh-keygen -l -f file -E md5

--- a/sites/leuven/macros.tex
+++ b/sites/leuven/macros.tex
@@ -10,6 +10,7 @@
 \macro{\hpcname}{Thinking}
 \macro{\loginnode}{login.hpc.kuleuven.be}
 \macro{\loginhost}{hpc-p-login-1}
+\macro{\altloginhost}{hpc-p-login-2}
 
 \newcommand{\opensshFirstConnect}{RSA key fingerprint is SHA256:0u4T6dV1esl/9DfBiN+GMo23e2g3lyKVtgoRvGqBlDc
 


### PR DESCRIPTION
During next week's maintenance, we are switching to new login nodes in the HPC-UGent infrastructure.

This change will me mostly transparent to users, but one important change that is the result of a stricter security policy is that it will no longer be possible to directly connect to a specific login node from outside of the HPC-UGent infrastructure.

Therefore, I have updated the VNC documentation to instruct users to set up the SSH tunnel to `login.hpc.ugent.be` (the generic name for the login nodes), and create an additional tunnel on the login node itself to port forward to the login node where the VNC server is running (if needed).

These instructions are generic, i.e. they will also work even if users are able to directly connect to a specific login node.