### PR TITLE
fix typo that broke building PDFs for intro-HPC

### DIFF
--- a/intro-HPC/ch_connecting.tex
+++ b/intro-HPC/ch_connecting.tex
@@ -504,7 +504,7 @@ user interface. Usually a locale identifier consists of at least a language
 identifier and a region identifier.
 
 \ifgent
-\strog{Note:} If you try to set a non-supported locale, then it will be
+\strong{Note:} If you try to set a non-supported locale, then it will be
 automatically set to the default. Currently the default is
 \lstinline|en_US.UFT-8| or \lstinline|en_US|, depending on whether your
 originally (non-supported) locale was \lstinline|UTF-8| or not.


### PR DESCRIPTION
merging #345 made the building of the PDFs fail because of a silly typo, fixed here

I'll follow up with another PR to make the exit code propagate properly if `make all` is used, so issues like this don't go undetected...