### PR TITLE
delete PBS_O_(V)NODENUM variables

### DIFF
--- a/intro-HPC/ch_torque_options.tex
+++ b/intro-HPC/ch_torque_options.tex
@@ -73,8 +73,6 @@ PBS\_O\_TZ       & value of the TZ variable in the environment in which \emph{qs
 PBS\_O\_HOST     & the name of the host upon which the \emph{qsub} command is running \\ \hline
 PBS\_O\_QUEUE    & the name of the original queue to which the job was submitted \\ \hline
 PBS\_O\_WORKDIR  & the absolute path of the current working directory of the \emph{qsub} command. This is the most useful. Use it in every job script. The first thing you do is, cd \$PBS\_O\_WORKDIR after defining the resource list. This is because, pbs throw you to your \$HOME directory. \\ \hline
-PBS\_O\_NODENUM  & node offset number \\ \hline
-PBS\_O\_VNODENUM & vnode offset number \\ \hline
 PBS\_VERSION     & Version Number of TORQUE, e.g., TORQUE-2.5.1 \\ \hline
 PBS\_MOMPORT     & active port for mom daemon \\ \hline
 PBS\_TASKNUM     & number of tasks requested \\ \hline


### PR DESCRIPTION
We do not have in Gent, but I have checked in Brussels, and PBS_O_NODENUM and PBS_O_VNODENUM variables are also missing. Anyway, I do not understand what did this mean based on the explanation. (Google did not help either, but I barely made any effort) 