### PR TITLE
fix URL of VSC firewall app

### DIFF
--- a/intro-HPC/ch_connecting.tex
+++ b/intro-HPC/ch_connecting.tex
@@ -29,7 +29,7 @@ you have the following options to get access to VSC login nodes:
       \ifgent
       See \url{https://helpdesk.ugent.be/vpn/en/} for more information.
       \fi
-  \item Register your IP address by accessing \url{https://firewall.hpc.kuleuven.be} (same URL regardless of the university you're affiliated with) and log in with your \university account.
+  \item Get your IP address automatically whitelisted by accessing \url{https://firewall.vscentrum.be} and log in with your \university account.
       \begin{itemize}
       \item While this web connection is active new SSH sessions can be started.
       \item Active SSH sessions will remain active even when this web page is closed.


### PR DESCRIPTION
used to be https://firewall.hpc.kuleuven.be, now https://firewall.vscentrum.be

minor issue, since https://firewall.hpc.kuleuven.be automatically redirects to https://firewall.vscentrum.be