### PR TITLE
fix OS picking for URLs without OS part

### DIFF
--- a/mkdocs_Antwerpen_OS_pick.yml
+++ b/mkdocs_Antwerpen_OS_pick.yml
@@ -51,4 +51,4 @@ theme:
     - search.highlight
 
 extra:
-  build_dir: build/HPC/intro-HPC
+  build_dir: build/HPC/Antwerpen

--- a/mkdocs_Gent_OS_pick.yml
+++ b/mkdocs_Gent_OS_pick.yml
@@ -51,4 +51,4 @@ theme:
     - search.highlight
 
 extra:
-  build_dir: build/HPC
+  build_dir: build/HPC/Gent


### PR DESCRIPTION
This restores the OS picking page for URLs like `<domain>/HPC/Gent/connecting/` which don't have an OS part in it, and redirects to the equivalent OS-specific URL like `<domain>/HPC/Gent/Windowsconnecting/`