### PR TITLE
Another path hack

### DIFF
--- a/build.py
+++ b/build.py
@@ -16,10 +16,11 @@ class BuildException(Exception):
         super().__init__(self.message)
 
     def __str__(self):
-        return f"""Subprocess stderr: {self.message}
+        return f"""
+        Subprocess stderr:
+        {self.message}
         Build process failed. -> Cleaning up and exiting.
-        To ignore errors and finish all partial builds,
-        use option '--ignore-errors'.
+        To ignore errors and finish all partial builds, use option '--ignore-errors'.
         """
 
 

--- a/build.py
+++ b/build.py
@@ -2,7 +2,6 @@ import argparse
 import os.path
 import shutil
 import subprocess
-import re
 from shutil import rmtree
 
 from yaml import safe_load

--- a/build.py
+++ b/build.py
@@ -2,6 +2,7 @@ import argparse
 import os.path
 import shutil
 import subprocess
+import re
 from shutil import rmtree
 
 from yaml import safe_load
@@ -15,8 +16,9 @@ class BuildException(Exception):
         super().__init__(self.message)
 
     def __str__(self):
-        return f"""\nSubprocess stderr:\n{self.message}\nBuild process failed. -> Cleaning up and exiting.\nTo ignore 
-        errors and finish all partial builds, use option '--ignore-errors'.\n """
+        return f"""\nSubprocess stderr:\n{self.message}\nBuild process failed.
+        -> Cleaning up and exiting.\nTo ignore errors and finish all partial builds,
+        use option '--ignore-errors'.\n """
 
 
 def load_config(landing_page_yml):
@@ -38,7 +40,11 @@ def load_config(landing_page_yml):
 def run_build(args, subsite):
     for subsite_dir, subsite_yml in subsite.items():
         build_dir, config = load_config(subsite_yml)
-        cmd = f"mkdocs build -f {subsite_yml} -d {os.path.join(build_dir, subsite_dir)}"
+        os_search = re.search(r'^\w+OS_pick\.yml', subsite[subsite_dir])
+        if os_search:
+            cmd = f"mkdocs build -f {subsite_yml} -d {os.path.join(build_dir)}"
+        else:
+            cmd = f"mkdocs build -f {subsite_yml} -d {os.path.join(build_dir, subsite_dir)}"
         print(f">> {cmd}")
         process = subprocess.run(cmd, shell=True, capture_output=True)
         if not args.ignore_errors and process.returncode != 0:

--- a/build.py
+++ b/build.py
@@ -16,9 +16,11 @@ class BuildException(Exception):
         super().__init__(self.message)
 
     def __str__(self):
-        return f"""\nSubprocess stderr:\n{self.message}\nBuild process failed.
-        -> Cleaning up and exiting.\nTo ignore errors and finish all partial builds,
-        use option '--ignore-errors'.\n """
+        return f"""Subprocess stderr: {self.message}
+        Build process failed. -> Cleaning up and exiting.
+        To ignore errors and finish all partial builds,
+        use option '--ignore-errors'.
+        """
 
 
 def load_config(landing_page_yml):
@@ -40,11 +42,10 @@ def load_config(landing_page_yml):
 def run_build(args, subsite):
     for subsite_dir, subsite_yml in subsite.items():
         build_dir, config = load_config(subsite_yml)
-        os_search = re.search(r'^\w+OS_pick\.yml', subsite[subsite_dir])
-        if os_search:
-            cmd = f"mkdocs build -f {subsite_yml} -d {os.path.join(build_dir)}"
-        else:
-            cmd = f"mkdocs build -f {subsite_yml} -d {os.path.join(build_dir, subsite_dir)}"
+        mkdocs_dir = [build_dir]
+        if not subsite_yml.endswith('OS_pick.yml'):
+            mkdocs_dir.append(subsite_dir)
+        cmd = f"mkdocs build -f {subsite_yml} -d {os.path.join(*mkdocs_dir)}"
         print(f">> {cmd}")
         process = subprocess.run(cmd, shell=True, capture_output=True)
         if not args.ignore_errors and process.returncode != 0:


### PR DESCRIPTION
Fixes: #482 

This is just a quick/dirty hack to use  `/HPC/<site>` path for os picks instead of `/HPC/<site>/<site>`. 

Also pylint shows several warnings for the current script:
```
build.py:1:0: C0114: Missing module docstring (missing-module-docstring)
build.py:24:0: C0116: Missing function or method docstring (missing-function-docstring)
build.py:24:16: W0621: Redefining name 'landing_page_yml' from outer scope (line 87) (redefined-outer-name)
build.py:28:8: W0621: Redefining name 'config' from outer scope (line 89) (redefined-outer-name)
build.py:32:4: W0621: Redefining name 'build_dir' from outer scope (line 89) (redefined-outer-name)
build.py:27:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
build.py:29:9: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
build.py:40:0: C0116: Missing function or method docstring (missing-function-docstring)
build.py:40:14: W0621: Redefining name 'args' from outer scope (line 86) (redefined-outer-name)
build.py:42:8: W0621: Redefining name 'build_dir' from outer scope (line 89) (redefined-outer-name)
build.py:42:19: W0621: Redefining name 'config' from outer scope (line 89) (redefined-outer-name)
build.py:45:12: W0621: Redefining name 'cmd' from outer scope (line 94) (redefined-outer-name)
build.py:49:18: W1510: 'subprocess.run' used without explicitly defining the value for 'check'. (subprocess-run-check)
build.py:42:19: W0612: Unused variable 'config' (unused-variable)
build.py:87:4: C0103: Constant name "landing_page_yml" doesn't conform to UPPER_CASE naming style (invalid-name)
build.py:96:19: W1510: 'subprocess.run' used without explicitly defining the value for 'check'. (subprocess-run-check)
```
