### PR TITLE
correct detecting verbose mode in build_cmd

### DIFF
--- a/build.py
+++ b/build.py
@@ -114,7 +114,7 @@ def build_cmd(cmd):
     print(f">> {cmd}")
     # combine stdout and stderr, so no capture_output; and yse text=True to avoid a bytestream
     process = subprocess.run(cmd, shell=True, text=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
-    if args.verbose or process.returncode != 0:
+    if ' --verbose ' in cmd or process.returncode != 0:
         print(f"{cmd} {process.stdout}")
     if process.returncode != 0:
         raise BuildException(f"{cmd} {process.stdout}")


### PR DESCRIPTION
fix for:

```
Traceback (most recent call last):
  File "/Volumes/work/vsc_user_docs/build.py", line 213, in <module>
    build_pool(pre)
  File "/Volumes/work/vsc_user_docs/build.py", line 140, in build_pool
    res = pool.map(build_cmd, cmds, 1)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/multiprocessing/pool.py", line 771, in get
    raise self._value
AttributeError: 'NoneType' object has no attribute 'verbose'
```

Global variables like `args` are not accessible from functions that are run via `pool.map`