### PR TITLE
Fix mkdocs instant loading 

### DIFF
--- a/custom_plugin/constants.py
+++ b/custom_plugin/constants.py
@@ -37,25 +37,3 @@ JS_SCROLL_STR = """
     )
 </script>
 """
-
-# loop over all
-#    <a class="headerlink" from text
-#    <a class="md-nav__link"> from index and TOC
-# strip the OS from the href of all of them if the localstorage has select_OS defined
-JS_OS_NEUTRAL = """
-<script>
-    if (!! localStorage.getItem('select_OS')) {
-        const classes = ["headerlink", "md-nav__link"]
-        for (i in classes) {
-            var anchors = Array.from(document.getElementsByClassName(classes[i]))
-            anchors.forEach(
-                function (anch) {
-                    //console.log("i", i, "class", classes[i], "anch.href", anch.href)
-                    if (!!anch.href) {
-                        anch.href = anch.href.replace(/\/(Linux|macOS|Windows)\//i, "/")
-                    }
-                })
-        }
-    }
-</script>
-"""

--- a/custom_plugin/custom_plugin.py
+++ b/custom_plugin/custom_plugin.py
@@ -14,7 +14,7 @@ from mkdocs.structure.files import File, Files
 from mkdocs.structure.pages import Page
 from yaml import safe_load
 
-from constants import JS_SCROLL_STR, OS_PICK_BTN, OS_PICK_STR, JS_OS_NEUTRAL
+from constants import JS_SCROLL_STR, OS_PICK_BTN, OS_PICK_STR
 
 """
 See https://www.mkdocs.org/user-guide/plugins/#developing-plugins for some more information
@@ -237,8 +237,6 @@ class UgentPlugin(BasePlugin):
         """
         if self.os_pick:
             output += JS_SCROLL_STR
-        if self.osneutrallinks:
-            output += JS_OS_NEUTRAL
         return output
 
     def on_post_build(self, config: Config):


### PR DESCRIPTION
Closes #543 

Deleted js code that remove's OS part from url in links with class `headerlink` or  `md-nav__link` (nav links on the left and right in docs). So that when the url is loaded, the saved OS (in browser storage) is put back in. This breaks instant loading (see #543) and isn't really helpful (**as far as I know**).

OS picking and redirect still works (when referencing a page with url without OS)