### PR TITLE
Make the build fail when macro syntax errors

### DIFF
--- a/config/templates/hpc.template
+++ b/config/templates/hpc.template
@@ -74,6 +74,7 @@ plugins:
           crontab_gent.md: crontab.md
 {%- endif %}
   - macros:
+      on_error_fail: true
       include_yaml:
         - extra/constants.yml
         - extra/{{ lsite }}.yml


### PR DESCRIPTION
More information about config settings see https://mkdocs-macros-plugin.readthedocs.io/en/latest/troubleshooting/