### PR TITLE
OS independent links

### DIFF
--- a/mkdocs/docs/HPC/overrides/main.html
+++ b/mkdocs/docs/HPC/overrides/main.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+{{ super() }}
+<script>
+ if (!! localStorage.getItem('select_OS')) {
+    const classes = ["headerlink", "md-nav__link"]
+    for (i in classes) {
+        var anchors = Array.from(document.getElementsByClassName(classes[i]))
+        anchors.forEach(
+            function (anch) {
+                const href = anch.href;
+                if (!!anch.href) {
+                    // Remove OS part and search query in permalinks if it exists. Useful when copying the urls.
+                    anch.href = anch.href.replace(/\/(Linux|macOS|Windows)\//i, "/").replace(/\?[^#]*/,"")
+                }
+                anch.addEventListener("click",(event) => {
+                    // Redirect to real original target. (with OS,and search query)
+                    event.target.href = href;
+                })
+            })
+    }
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
Fixes #558 

I restored most of the code when deleting it in #547. 
I put it in `overrides/main.html` instead, so that is is executed every time.

Instant loading stills works as I added a  listener that changes the `href` to the original value again when clicking on the url.

The search query is now also removed from permalinks (will still be added when clicking, but not when copying,  see above)