### PR TITLE
fix: incorrect scp command

### DIFF
--- a/mkdocs/docs/HPC/connecting.md
+++ b/mkdocs/docs/HPC/connecting.md
@@ -606,7 +606,7 @@ remote filesystem by putting a path after the colon.
 <b>$ ls -l </b>
 ...
 -rw-r--r-- 1 user  staff   6 Sep 18 09:37 localfile.txt
-$ scp localfile.txt {{ userid }}@{{ loginnode }}
+$ scp localfile.txt {{ userid }}@{{ loginnode }}:
 localfile.txt     100%   6     0.0KB/s     00:00
 </code></pre>
 


### PR DESCRIPTION
Like the docs are warning about:

> Don't forget the colon (`:`) at the end: if you forget it, it will just create a file named vsc40000@login.hpc.ugent.be on your local filesystem.

I added the semicolon to the command.