### PR TITLE
added missing link to join VO

### DIFF
--- a/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
+++ b/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
@@ -299,7 +299,7 @@ scratch space instead.
 
 {% if site == gent %}
 If you are running out of quota on your
-_$VSC_DATA filesystem you can request a VO. See on how to do this.
+_$VSC_DATA filesystem you can request to join a VO. See [this section](./#joining-an-existing-vo) on how to do this.
 {% endif %}
 
 ### Your scratch space ($VSC_SCRATCH)

--- a/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
+++ b/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
@@ -299,7 +299,7 @@ scratch space instead.
 
 {% if site == gent %}
 If you are running out of quota on your
-_$VSC_DATA filesystem you can request to join a VO. See [this section](./#joining-an-existing-vo) on how to do this.
+_$VSC_DATA filesystem you can join an existing VO, or request a new VO. See [the section about virtual organisations](./#virtual-organisations) on how to do this.
 {% endif %}
 
 ### Your scratch space ($VSC_SCRATCH)


### PR DESCRIPTION
I'm not quite sure about this change. It is clear an internal link is missing, but i'm not sure if the author intended the reader to make or to join a VO. It seems more logical to me to join one.

Also, the link I added links to a block only visible for Gent and Brussel, but is visible for all users.