### PR TITLE
Du hidden files command

### DIFF
--- a/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
+++ b/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
@@ -774,7 +774,7 @@ just pass this directory as a parameter. The command below will show the
 disk use in your home directory, even if you are currently in a
 different directory:
 
-<pre><code><b>$ du -h --max-depth 1 $VSC_HOME/*</b>
+<pre><code><b>$ du -h --max-depth 1 $VSC_HOME</b>
 22M {{ homedir }}/dataset01
 36M {{ homedir }}/dataset02
 22M {{ homedir }}/dataset03

--- a/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
+++ b/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
@@ -758,13 +758,14 @@ for a summary of the current directory:
 If you want to see the size of any file or top-level subdirectory in the
 current directory, you could use the following command:
 
-<pre><code><b>$ du -s -h *</b>
-1.5M ex01-matlab
-512K ex02-python
-768K ex03-python
-768K ex04-python
-256K example.sh
-1.5M intro-HPC.pdf
+<pre><code><b>$ du -h --max-depth 1</b>
+1.5M ./ex01-matlab
+512K ./ex02-python
+768K ./ex03-python
+768K ./ex04-python
+256K ./example.sh
+1.5M ./intro-HPC.pdf
+700M ./.cache
 </code></pre>
 
 Finally, if you don't want to know the size of the data in your current
@@ -773,11 +774,12 @@ just pass this directory as a parameter. The command below will show the
 disk use in your home directory, even if you are currently in a
 different directory:
 
-<pre><code><b>$ du -h $VSC_HOME/*</b>
+<pre><code><b>$ du -h --max-depth 1 $VSC_HOME/*</b>
 22M {{ homedir }}/dataset01
 36M {{ homedir }}/dataset02
 22M {{ homedir }}/dataset03
 3.5M {{ homedir }}/primes.txt
+24M {{ homedir }}/.cache
 </code></pre>
 
 {% if site == gent %}


### PR DESCRIPTION
This pull request suggests changing the `-s` and `*` for `--max-depth 1` in the last two examples on `du` usage. There are two reasons for this suggestion:

Firstly, the docs say:
 > If you want to see the size of ***any*** file or top-level subdirectory in the current directory, you could use the following command: `du -s -h *`

Because `*` does not expand hidden files and directories it could be misleading for users trying to figure out the space their files are taking up. In contrast, `--max-depth 1` does take this into account.  

Secondly, I overheard @hajgato say users who hit quota frequently overlook hidden files and directories when cleaning up disk space. Some unnecessary tickets could be avoided with the new commands  