### PR TITLE
changed the name of the example folder for multi core jobs tutorial

### DIFF
--- a/mkdocs/docs/HPC/multi_core_jobs.md
+++ b/mkdocs/docs/HPC/multi_core_jobs.md
@@ -1,4 +1,4 @@
-{% set exampledir = 'examples/Multi_core_jobs_Parallel_Computing' %}
+{% set exampledir = 'examples/Multi-core-jobs-Parallel-Computing' %}
 
 # Multi core jobs/Parallel Computing 
 


### PR DESCRIPTION
`Multi_core_jobs_Parallel_Computing` does not actually exist, it should be `Multi-core-jobs-Parallel-Computing`