### PR TITLE
typo fix in interactive_debug.md

### DIFF
--- a/mkdocs/docs/HPC/interactive_debug.md
+++ b/mkdocs/docs/HPC/interactive_debug.md
@@ -4,7 +4,7 @@
 
 The purpose of this cluster is to give the user an environment where
 there should be no waiting in the queue to get access to a limited
-number of resources. This environment allows a user to immediatelty
+number of resources. This environment allows a user to immediately
 start working, and is the ideal place for interactive work such as
 development, debugging and light production workloads (typically
 sufficient for training and/or courses).


### PR DESCRIPTION
immediatelty -> immediately. For the rest the section seems free of typos and is well structured