### PR TITLE
compile eat_cpu before running

### DIFF
--- a/mkdocs/docs/HPC/fine_tuning_job_specifications.md
+++ b/mkdocs/docs/HPC/fine_tuning_job_specifications.md
@@ -515,9 +515,10 @@ The **uptime** command will show us the average load
 10:14:05 up 86 days, 12:01, 11 users, load average: 0.60, 0.41, 0.41
 </code></pre>
 
-Now, start a few instances of the "*eat_cpu*" program in the background,
+Now, compile and start a few instances of the "*eat_cpu*" program in the background,
 and check the effect on the load again:
-<pre><code>$ <b>./eat_cpu&</b>
+<pre><code>$ <b>gcc eat_cpu.c -o eat_cpu</b>
+$ <b>./eat_cpu&</b>
 $ <b>./eat_cpu&</b>
 $ <b>./eat_cpu&</b>
 $ <b>uptime</b>

--- a/mkdocs/docs/HPC/fine_tuning_job_specifications.md
+++ b/mkdocs/docs/HPC/fine_tuning_job_specifications.md
@@ -517,7 +517,7 @@ The **uptime** command will show us the average load
 
 Now, compile and start a few instances of the "*eat_cpu*" program in the background,
 and check the effect on the load again:
-<pre><code>$ <b>gcc eat_cpu.c -o eat_cpu</b>
+<pre><code>$ <b>gcc -O2 eat_cpu.c -o eat_cpu</b>
 $ <b>./eat_cpu&</b>
 $ <b>./eat_cpu&</b>
 $ <b>./eat_cpu&</b>


### PR DESCRIPTION
As the `eat_cpu` binary is not present in `examples/Fine-tuning-Job-Specifications`, it must first be compiled. I added this to the docs.

![image](https://github.com/hpcugent/vsc_user_docs/assets/63658577/870cb227-5450-4109-9b30-1ddbe4a1d1d6)
