### PR TITLE
Module available fix

### DIFF
--- a/mkdocs/docs/HPC/sites/gent/available-modules.md
+++ b/mkdocs/docs/HPC/sites/gent/available-modules.md
@@ -1,4 +1,4 @@
-<pre><code>$ <b>module av 2>&1 | more</b>
+<pre><code>$ <b>module av | more</b>
 --- /apps/gent/SL6/sandybridge/modules/all ---
 ABAQUS/6.12.1-linux-x86_64
 AMOS/3.1.0-ictce-4.0.10
@@ -11,11 +11,11 @@ ASE/3.6.0.2515-ictce-5.5.0-Python-2.7.6
 Or when you want to check whether some specific software, some compiler or some
 application (e.g., MATLAB) is installed on the {{hpc}}.
 
-<pre><code>$ <b>module av 2>&1 | grep -i -e "matlab"</b>
-MATLAB/2010b
-MATLAB/2012b
-MATLAB/2013b
+<pre><code>$ <b>module av matlab</b>
+--------------------- /apps/gent/RHEL8/zen2-ib/modules/all ---------------------
+   LIBSVM-MATLAB/3.30-GCCcore-11.3.0-MATLAB-2022b-r5
+   MATLAB/2019b
+   MATLAB/2021b
+   MATLAB/2022b-r5                                   (D)
+   SPM/12.5_r7771-MATLAB-2021b
 </code></pre>
-
-As you are not aware of the capitals letters in the module name, we looked for
-a case-insensitive name with the "-i" option.

--- a/mkdocs/docs/HPC/sites/gent/available-modules.md
+++ b/mkdocs/docs/HPC/sites/gent/available-modules.md
@@ -1,10 +1,10 @@
 <pre><code>$ <b>module av | more</b>
---- /apps/gent/SL6/sandybridge/modules/all ---
-ABAQUS/6.12.1-linux-x86_64
-AMOS/3.1.0-ictce-4.0.10
-ant/1.9.0-Java-1.7.0_40
-ASE/3.6.0.2515-ictce-4.1.13-Python-2.7.3
-ASE/3.6.0.2515-ictce-5.5.0-Python-2.7.6
+--- /apps/gent/RHEL8/zen2-ib/modules/all ---
+   ABAQUS/2021-hotfix-2132
+   ABAQUS/2022-hotfix-2214
+   ABAQUS/2022
+   ABAQUS/2023
+   ABAQUS/2024-hotfix-2405                                                (D)
 ...
 </code></pre>
 
@@ -12,7 +12,7 @@ Or when you want to check whether some specific software, some compiler or some
 application (e.g., MATLAB) is installed on the {{hpc}}.
 
 <pre><code>$ <b>module av matlab</b>
---------------------- /apps/gent/RHEL8/zen2-ib/modules/all ---------------------
+--- /apps/gent/RHEL8/zen2-ib/modules/all ---
    LIBSVM-MATLAB/3.30-GCCcore-11.3.0-MATLAB-2022b-r5
    MATLAB/2019b
    MATLAB/2021b

--- a/mkdocs/docs/HPC/sites/gent/available-modules.md
+++ b/mkdocs/docs/HPC/sites/gent/available-modules.md
@@ -5,7 +5,7 @@
    ABAQUS/2022
    ABAQUS/2023
    ABAQUS/2024-hotfix-2405                                                (D)
-...
+   ...
 </code></pre>
 
 Or when you want to check whether some specific software, some compiler or some


### PR DESCRIPTION
In this pull request, I changed three things about the way searching modules is documented:

1. I removed `2>&1` from `module av 2>&1`, as the `module av` command does not write to stderr
2. I replaced the use of grep in `module av| grep -i -e "matlab"` by the built in search feature (`module ab matlab`). This is because when the terminal window is big enough, the output is displayed in two columns, adding non-matlab modules to the grep results: ![image](https://github.com/hpcugent/vsc_user_docs/assets/63658577/946895a3-5816-4c6c-959c-7828625a5fab)
3. I updated the output to reflect the current top modules

The end result looks like this:

![image](https://github.com/hpcugent/vsc_user_docs/assets/63658577/98755bd4-1c47-4ac5-97a9-ef9c420451a4)
