### PR TITLE
Update modules in examples

### DIFF
--- a/intro-HPC/examples/Compiling-and-testing-your-software-on-the-HPC/mpihello.pbs
+++ b/intro-HPC/examples/Compiling-and-testing-your-software-on-the-HPC/mpihello.pbs
@@ -12,6 +12,6 @@ cd $PBS_O_WORKDIR
   # load the environment
 
 module purge
-module load intel
+module load foss
 
 mpirun ./mpihello

--- a/intro-HPC/examples/HPC-UGent-GPU-clusters/TensorFlow_GPU.sh
+++ b/intro-HPC/examples/HPC-UGent-GPU-clusters/TensorFlow_GPU.sh
@@ -2,7 +2,7 @@
 #PBS -l walltime=5:0:0
 #PBS -l nodes=1:ppn=quarter:gpus=1
 
-module load TensorFlow/2.6.0-foss-2021a-CUDA-11.3.1
+module load TensorFlow/2.11.0-foss-2022a-CUDA-11.7.0
 
 cd $PBS_O_WORKDIR
 python example.py

--- a/intro-HPC/examples/Job-script-examples/multi_core.sh
+++ b/intro-HPC/examples/Job-script-examples/multi_core.sh
@@ -2,7 +2,7 @@
 #PBS -N mpi_hello             ## job name
 #PBS -l nodes=2:ppn=all       ## 2 nodes, all cores per node
 #PBS -l walltime=2:00:00      ## max. 2h of wall time
-module load intel/2017b
+module load foss/2023a
 module load vsc-mympirun      ## We don't use a version here, this is on purpose
 # go to working directory, compile and run MPI hello world
 cd $PBS_O_WORKDIR

--- a/intro-HPC/examples/Job-script-examples/single_core.sh
+++ b/intro-HPC/examples/Job-script-examples/single_core.sh
@@ -2,7 +2,7 @@
 #PBS -N count_example         ## job name
 #PBS -l nodes=1:ppn=1         ## single-node job, single core
 #PBS -l walltime=2:00:00      ## max. 2h of wall time
-module load Python/3.6.4-intel-2018a
+module load Python/3.11.3-GCCcore-12.3.0
 # copy input data from location where job was submitted from
 cp $PBS_O_WORKDIR/input.txt $TMPDIR
 # go to temporary working directory (on local disk) & run

--- a/intro-HPC/examples/MATLAB/jobscript.sh
+++ b/intro-HPC/examples/MATLAB/jobscript.sh
@@ -7,7 +7,7 @@
 #
 
 # make sure the MATLAB version matches with the one used to compile the MATLAB program!
-module load MATLAB/2018a
+module load MATLAB/2022b-r5
 
 # use temporary directory (not $HOME) for (mostly useless) MATLAB log files
 # subdir in $TMPDIR (if defined, or /tmp otherwise)

--- a/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/mpi_hello.pbs
+++ b/intro-HPC/examples/Multi-core-jobs-Parallel-Computing/mpi_hello.pbs
@@ -11,6 +11,6 @@ cd $PBS_O_WORKDIR
 
   # load the environment
 
-module load intel
+module load foss
 
 mpirun ./mpi_hello

--- a/intro-HPC/examples/OpenFOAM/OpenFOAM_damBreak.sh
+++ b/intro-HPC/examples/OpenFOAM/OpenFOAM_damBreak.sh
@@ -2,7 +2,7 @@
 #PBS -l walltime=1:0:0
 #PBS -l nodes=1:ppn=4
 # check for more recent OpenFOAM modules with 'module avail OpenFOAM'
-module load OpenFOAM/6-intel-2018a
+module load OpenFOAM/11-foss-2023a
 source $FOAM_BASH
 # purposely not specifying a particular version to use most recent mympirun
 module load vsc-mympirun

--- a/intro-HPC/examples/Program-examples/04_MPI_C/mpihello.pbs
+++ b/intro-HPC/examples/Program-examples/04_MPI_C/mpihello.pbs
@@ -13,6 +13,6 @@ cd $PBS_O_WORKDIR
   # load the environment
 
 module purge
-module load intel
+module load foss
 
 mpirun ./mpihello


### PR DESCRIPTION
A number of the examples will fail because of the outdated modules that are no longer available on the cluster or loading intel toolchains on AMD system.

Linked to this OTRS ticket: [#202407236000017](https://otrsdict.ugent.be/otrs/index.pl?Action=AgentTicketZoom&TicketID=162880)