### PR TITLE
Add error to available_modules.py when not called from child dir of 'vsc_user_docs'

### DIFF
--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -54,9 +54,13 @@ def main():
 
     current_dir = Path(__file__).resolve()
     project_name = 'vsc_user_docs'
-    root_dir = next(
+    root_dirs = [
         p for p in current_dir.parents if p.parts[-1] == project_name
-    )
+    ]
+
+    assert len(root_dirs) > 0, f"This script must be called from a child directory of '{project_name}'"
+
+    root_dir = root_dirs[0]
     path_data_dir = os.path.join(root_dir, "mkdocs/docs/HPC/only/gent/available_software/data")
 
     # Generate the JSON overviews and detail markdown pages.


### PR DESCRIPTION
when you clone the docs in a directory not named 'vsc_user_docs' and run the `available_modules.py` script, you get the following cryptic error:

```
Traceback (most recent call last):
  File "available_software.py", line 603, in <module>
    main()
  File "available_software.py", line 58, in main
    p for p in current_dir.parents if p.parts[-1] == project_name
StopIteration
```

I did not fix this, but added an assertion error which points out the problem