### PR TITLE
Timestamp variable in available software script

### DIFF
--- a/mkdocs/extra/gent.yml
+++ b/mkdocs/extra/gent.yml
@@ -16,7 +16,7 @@ hpcname: hpcugent
 loginnode: login.hpc.ugent.be
 loginhost: gligar07.gastly.os
 altloginhost: gligar08.gastly.os
-modules_last_updated: 2021-09-01
+modules_last_updated: Mon, 09 Sep 2024 at 14:06:35 CEST
 # get these with ssh-keyscan gligar01.ugent.be > file
 # ssh-keygen -l -f file
 # ssh-keygen -l -f file -E md5

--- a/mkdocs/extra/gent.yml
+++ b/mkdocs/extra/gent.yml
@@ -16,7 +16,7 @@ hpcname: hpcugent
 loginnode: login.hpc.ugent.be
 loginhost: gligar07.gastly.os
 altloginhost: gligar08.gastly.os
-modules_last_updated: Mon, 09 Sep 2024 at 14:06:35 CEST
+modules_last_updated: Mon, 09 Sep 2024 at 14:06:35 CEST # This line is automatically updated by scripts/available_modules/available_modules.py
 # get these with ssh-keyscan gligar01.ugent.be > file
 # ssh-keygen -l -f file
 # ssh-keygen -l -f file -E md5

--- a/mkdocs/extra/gent.yml
+++ b/mkdocs/extra/gent.yml
@@ -16,6 +16,7 @@ hpcname: hpcugent
 loginnode: login.hpc.ugent.be
 loginhost: gligar07.gastly.os
 altloginhost: gligar08.gastly.os
+modules_last_updated: 2021-09-01
 # get these with ssh-keyscan gligar01.ugent.be > file
 # ssh-keygen -l -f file
 # ssh-keygen -l -f file -E md5

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -39,7 +39,7 @@ from typing import Union, Tuple
 import numpy as np
 from mdutils.mdutils import MdUtils
 from natsort import natsorted
-import yaml
+from ruamel.yaml import YAML
 
 
 # --------------------------------------------------------------------------------------------------------
@@ -423,17 +423,17 @@ def update_generated_time_yml(generated_time_yml, generated_time) -> None:
     @param generated_time_yml: Path to the YAML file containing the field 'modules_last_updated'
     @param generated_time: Time the data was generated
     """
+    key = "modules_last_updated"
+
+    # Read the file and replace the specific line
     with open(generated_time_yml, 'r') as file:
-        data = yaml.safe_load(file)
+        lines = file.readlines()
 
-    # Update the 'modules_last_updated' field
-    data['modules_last_updated'] = generated_time  # Set the new date here
-
-    # Write the updated YAML back to the file
     with open(generated_time_yml, 'w') as file:
-        yaml.safe_dump(data, file)
-
-
+        for line in lines:
+            if line.startswith(key):
+                line = f"{key}: {generated_time}\n"
+            file.write(line)
 # --------------------------------------------------------------------------------------------------------
 # Generate overview markdown
 # --------------------------------------------------------------------------------------------------------

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -433,12 +433,14 @@ def update_generated_time_yml(generated_time_yml, generated_time) -> None:
     with open(generated_time_yml, 'w') as file:
         for line in lines:
             if line.startswith(key):
-                line = f"{key}: {generated_time}\n"
+                line = f"{key}: {generated_time} # This line is automatically updated by scripts/available_modules/available_modules.py\n"
                 replaced = True
             file.write(line)
 
     if not replaced:
         print(f"WARNING: Could not find the key '{key}' in the YAML file '{generated_time_yml}'")
+
+
 # --------------------------------------------------------------------------------------------------------
 # Generate overview markdown
 # --------------------------------------------------------------------------------------------------------

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -418,6 +418,7 @@ def generate_detail_pages(json_path, dest_path, generated_time_yml) -> None:
 def update_generated_time_yml(generated_time_yml, generated_time) -> None:
     """
     Update the time the data was generated in the YAML file.
+    This is done by updating the field 'modules_last_updated'.
 
     @param generated_time_yml: Path to the YAML file containing the field 'modules_last_updated'
     @param generated_time: Time the data was generated

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -381,7 +381,7 @@ def generate_software_detail_page(
     md_file.new_paragraph(f"To start using {software_name}, load one of these modules using a `module load` command "
                           f"like:")
     md_file.insert_code(f"module load {newest_version}", language="shell")
-    md_file.new_paragraph(f"(This data was automatically generated on {generated_time})", bold_italics_code="i")
+    md_file.new_paragraph("(This data was automatically generated on {{modules_last_updated}})", bold_italics_code="i")
     md_file.new_line()
 
     md_file.new_table(

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -39,7 +39,6 @@ from typing import Union, Tuple
 import numpy as np
 from mdutils.mdutils import MdUtils
 from natsort import natsorted
-from ruamel.yaml import YAML
 
 
 # --------------------------------------------------------------------------------------------------------

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -78,7 +78,7 @@ def main():
     print("Done!")
     print("Generate detailed pages... ", end="", flush=True)
     detail_folder = os.path.join(root_dir, "mkdocs/docs/HPC/only/gent/available_software/detail")
-    generated_time_yml = os.path.join(root_dir, "mkdocs/extra/gent.yml") # yml containing the time the data was generated
+    generated_time_yml = os.path.join(root_dir, "mkdocs/extra/gent.yml")  # yml containing time the data was generated
     generate_detail_pages(json_path, detail_folder, generated_time_yml)
     print("Done!")
 
@@ -433,7 +433,8 @@ def update_generated_time_yml(generated_time_yml, generated_time) -> None:
     with open(generated_time_yml, 'w') as file:
         for line in lines:
             if line.startswith(key):
-                line = f"{key}: {generated_time} # This line is automatically updated by scripts/available_modules/available_modules.py\n"
+                comment = "# This line is automatically updated by scripts/available_modules/available_modules.py"
+                line = f"{key}: {generated_time} {comment}\n"
                 replaced = True
             file.write(line)
 

--- a/scripts/available_software/available_software.py
+++ b/scripts/available_software/available_software.py
@@ -428,11 +428,16 @@ def update_generated_time_yml(generated_time_yml, generated_time) -> None:
     with open(generated_time_yml, 'r') as file:
         lines = file.readlines()
 
+    replaced = False
     with open(generated_time_yml, 'w') as file:
         for line in lines:
             if line.startswith(key):
                 line = f"{key}: {generated_time}\n"
+                replaced = True
             file.write(line)
+
+    if not replaced:
+        print(f"WARNING: Could not find the key '{key}' in the YAML file '{generated_time_yml}'")
 # --------------------------------------------------------------------------------------------------------
 # Generate overview markdown
 # --------------------------------------------------------------------------------------------------------

--- a/scripts/available_software/requirements.txt
+++ b/scripts/available_software/requirements.txt
@@ -1,3 +1,4 @@
 mdutils
 numpy
 natsort
+PyYAML

--- a/scripts/available_software/requirements.txt
+++ b/scripts/available_software/requirements.txt
@@ -1,4 +1,3 @@
 mdutils
 numpy
 natsort
-PyYAML


### PR DESCRIPTION
This PR changes `script/available_software/available_software.py` to use `{{modules_last_updated}}` instead of hardcoding the last changed timestamp in every markdown file. This makes Pull requests containing changes made by the script a lot smaller (also see PR #680).

I added the `modules_last_updates` variable to `mkdocs/extra/gent.yml`. Every time the script runs, it updates the line beginning with `modules_last_updated: ` 

closes #681 