### PR TITLE
Fix wrongly formatted code block in note

### DIFF
--- a/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
+++ b/mkdocs/docs/HPC/running_jobs_with_input_output_data.md
@@ -21,7 +21,7 @@ cd ~/{{ exampledir }}
     If the example directory is not yet present, copy it to your home directory:
 
     ```
-cp -r {{ examplesdir }} ~/
+    cp -r {{ examplesdir }} ~/
     ```
 
 


### PR DESCRIPTION
This note was wrongly formatted:

![image](https://github.com/user-attachments/assets/be861a80-f610-4b90-866e-105568991339)

This was introduced in 24739b2. 

We should probably check notes, tips, ... for code blocks which previously contained `$`