### PR TITLE
Remove fetch depth 0 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # test
 
       - name: set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # test
 
       - name: set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
In the Github action, `fetch-depth: 0` clones the repo with its entire history. I skimmed through the build scripts and it seems we dont do anything with previous commits. Removing the `fetch-depth: 0` makes the workflow only check out the last commit. This brings the "checkout time" form ~30s to ~1s:

`fetch-depth: 0`:
![fd0](https://github.com/user-attachments/assets/6b5dd93a-8b8f-46f8-b1fb-31a7064e55a0)
`fetch-depth: 1 (default)`:
![fd1](https://github.com/user-attachments/assets/bb0c64a0-46af-4f14-a14f-2970f69c9116)

which brings the total time from ~3m to ~2m30s
