### PR TITLE
fix rendering of list items on Transcribe page

### DIFF
--- a/mkdocs/docs/HPC/transcribe.md
+++ b/mkdocs/docs/HPC/transcribe.md
@@ -11,6 +11,7 @@ The main use case is sporadic transcription of audio or video files. There is in
 to help with large scale projects.
 
 The supported flow is:
+
 - Upload audio or video file using the `Files` interface of the web portal
 - Configure transcription via the `Interactive Apps` -> `Transcribe` application (currently under `Testing` section at the bottom);
   you can select `Whisper inputfile` and `Whisper languages`.


### PR DESCRIPTION
empty line is required before starting list items to ensure it's rendered correctly