### PR TITLE
Remove non-VO dirs from data retention policy

### DIFF
--- a/mkdocs/docs/HPC/sites/hpc_policies.md
+++ b/mkdocs/docs/HPC/sites/hpc_policies.md
@@ -92,7 +92,7 @@ Once the voluntary employee contract is in order, HPC staff can then reinstate t
 #### Data transfer by HPC staff
 
 As a very last resort measure, HPC staff can perform a data transfer to another VSC account when requested by a VO moderator or promotor.
-If the former user was member of a VO, we will assume all the data is owned by the VO moderator or promotor (including $VSC_HOME and $VSC_DATA directories).
+If the former user was member of a VO, we will assume all the data is owned by the VO moderator or promotor.
 
 Please be aware that such a data transfer is a non-trivial operation for HPC-UGent staff:
 


### PR DESCRIPTION
In the old system, user had to sign a document and it was clear all data (including non-VO VSC_HOME, VSC_SCRATCH, VSC_DATA, VSC_ARCANINE_SCRATCH) would go to the new data owner. In the new system we do not have this clearly formulated, so I would leave the non-VO locations as it is (VSC_HOME can contain sensitive information like ssh-private-keys, etc). 
Moreover, if users were member of multiple VOs, its not easy to determine (without the explicit request of the user), to which VO should ve transfer the non-VO directories. In general, the leftover data of non-VO location is very small, so it would not cause any storage space problems. 
We also write that promotors can get the data, but how we can check that? What if the promotor does not have a vsc account?